### PR TITLE
Viral alignments often have long runs of NNNs in...

### DIFF
--- a/make_prg/__main__.py
+++ b/make_prg/__main__.py
@@ -71,6 +71,12 @@ def main():
         "-p", "--prefix", dest="output_prefix", action="store", help="Output prefix"
     )
     subparser_prg_from_msa.add_argument(
+        "--staggered_start",
+        dest="staggered_start",
+        action="store_true",
+        help="Assume dashes at start of alignment are due to missing data, rather than indels",
+    )
+    subparser_prg_from_msa.add_argument(
         "--no_overwrite",
         dest="no_overwrite",
         action="store_true",

--- a/make_prg/make_prg_from_msa.py
+++ b/make_prg/make_prg_from_msa.py
@@ -527,9 +527,6 @@ class AlignedSeq(object):
                     logging.warning(
                         "Key %s doesn't seem to be in either big keys or small keys"
                     )
-        #assert len(interval_alignment) == sum(
-        #    [len(i) for i in return_id_lists]
-        #), "I seem to have lost (or gained?) some sequences in the process of clustering"
         assert (
             len(return_id_lists) > 1
         ), "should have some alternate alleles, not only one sequence, this is a non-match interval"

--- a/make_prg/subcommands/prg_from_msa.py
+++ b/make_prg/subcommands/prg_from_msa.py
@@ -49,6 +49,7 @@ def run(options):
             alignment_format=options.alignment_format,
             max_nesting=options.max_nesting,
             min_match_length=options.min_match_length,
+            staggered_start=options.staggered_start,
             prg_file=prg_file,
         )
     else:
@@ -57,6 +58,7 @@ def run(options):
             alignment_format=options.alignment_format,
             max_nesting=options.max_nesting,
             min_match_length=options.min_match_length,
+            staggered_start=options.staggered_start,
         )
         logging.info("Write PRG file to %s.prg", prefix)
         utils.write_prg(prefix, aseq.prg)

--- a/make_prg/utils.py
+++ b/make_prg/utils.py
@@ -11,6 +11,8 @@ def remove_duplicates(seqs: Sequence) -> Generator:
     for x in seqs:
         if x in seen:
             continue
+        elif list(set(x)) == ["N"]:
+            continue
         seen.add(x)
         yield x
 


### PR DESCRIPTION
Handle by disallowing alleles in non-match intervals which are entirely N.
The result/consequence is that we need to allow for fewer sequences to be considered after running kmeans_clustering. 
Also add a command line flag for staggered starts, which assumes that dashes at the start of an alignment are due to incomplete sequences rather than true indel differences.