### PR TITLE
Gramtools compatibility + clearer CLI and output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `--prefix` CLI parameter of `from_msa` subcommand removed in favor of CLI parameters `--outdir`
+   and `--prg_name`, with sensible defaults (current working directory and MSA file name stem respectively).
+   This allows finer control over where to place output files.
+- Output files no longer contain 'max_nesting' and 'min_match_length' in their names; these appear in the log files,
+  and in the `.prg` fasta header.
+- `.bin` file now stores even integer markers at site ends; this is the format used by gramtools.
+
 ## [0.1.1] - 2021-01-22
 ### Added
 - Dockerfile

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -54,10 +54,11 @@ def register_parser(subparsers):
     )
     subparser_msa.add_argument(
         "-o",
-        "--output_dir",
+        "--outdir",
         dest="output_dir",
         action="store",
-        help="Output directory. Default: location of MSA file",
+        default=".",
+        help="Output directory. Default: Current working directory",
     )
     subparser_msa.add_argument(
         "-n",
@@ -81,10 +82,7 @@ def run(options):
     MSA_file = Path(options.MSA).resolve()
     if not MSA_file.exists():
         raise ValueError(f"File not found: {options.MSA}")
-    if options.output_dir is None:
-        output_dir = MSA_file.parent
-    else:
-        output_dir = Path(options.output_dir).resolve()
+    output_dir = Path(options.output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if options.prg_name is None:

--- a/tests/test_prg_encoder.py
+++ b/tests/test_prg_encoder.py
@@ -10,7 +10,7 @@ from make_prg.prg_encoder import PrgEncoder, ConversionError, EncodeError, to_by
 
 
 class TestDnaToInt(TestCase):
-    def test_dnaToInt_empty_string_raises_assert_error(self):
+    def test_empty_string_raises_assert_error(self):
         encoder = PrgEncoder()
         char = ""
 
@@ -20,13 +20,13 @@ class TestDnaToInt(TestCase):
         self.assertTrue("Char '' is not in" in str(context.exception))
 
     @given(characters(blacklist_characters="ACGTacgt", max_codepoint=10000))
-    def test_dnaToInt_char_not_valid_raises_assert_error(self, char):
+    def test_char_not_valid_raises_assert_error(self, char):
         encoder = PrgEncoder()
 
         with self.assertRaises(ConversionError):
             encoder._dna_to_int(char)
 
-    def test_dnaToInt_default_encoding_int(self):
+    def test_default_encoding_int(self):
         encoder = PrgEncoder()
         uppercase = encoder._dna_to_int("A")
         expected = 1
@@ -35,7 +35,7 @@ class TestDnaToInt(TestCase):
         lowercase = encoder._dna_to_int("a")
         self.assertEqual(lowercase, expected)
 
-    def test_dnaToInt_custom_encoding(self):
+    def test_custom_encoding(self):
         encoder = PrgEncoder(encoding={"A": 7})
         char = "a"
 
@@ -46,15 +46,13 @@ class TestDnaToInt(TestCase):
 
 
 class TestEncodeUnit(TestCase):
-    def test_encode_empty_string_fails(self):
+    def test_empty_string_fails(self):
         encoder = PrgEncoder()
         with self.assertRaises(EncodeError):
             encoder._encode_unit("")
 
     @patch.object(PrgEncoder, "_dna_to_int", side_effect=[1, 2, 3, 4])
-    def test_encode_unit_dna_returns_list_of_ints_between_1_and_4(
-        self, mock_method: Mock
-    ):
+    def test_dna_returns_list_of_ints_between_1_and_4(self, mock_method: Mock):
         encoder = PrgEncoder()
         actual = encoder._encode_unit("ACGT")
         expected = [1, 2, 3, 4]
@@ -86,7 +84,7 @@ class TestEncodeUnit(TestCase):
         prg = "5 A 6 C 5"
 
         actual = encoder.encode(prg)
-        expected = [5, 1, 6, 2, 5]
+        expected = [5, 1, 6, 2, 6]
 
         self.assertEqual(actual, expected)
 
@@ -95,7 +93,7 @@ class TestEncodeUnit(TestCase):
         prg = " 5  6 C 5 "
 
         actual = encoder.encode(prg)
-        expected = [5, 6, 2, 5]
+        expected = [5, 6, 2, 6]
 
         self.assertEqual(actual, expected)
 
@@ -104,7 +102,7 @@ class TestEncodeUnit(TestCase):
         prg = " 5 C 6  5 "
 
         actual = encoder.encode(prg)
-        expected = [5, 2, 6, 5]
+        expected = [5, 2, 6, 6]
 
         self.assertEqual(actual, expected)
 
@@ -113,7 +111,7 @@ class TestEncodeUnit(TestCase):
         prg = "5 GA 6 CT 5"
 
         actual = encoder.encode(prg)
-        expected = [5, 3, 1, 6, 2, 4, 5]
+        expected = [5, 3, 1, 6, 2, 4, 6]
 
         self.assertEqual(actual, expected)
 
@@ -122,7 +120,7 @@ class TestEncodeUnit(TestCase):
         prg = "55 GA 63 Ct 55"
 
         actual = encoder.encode(prg)
-        expected = [55, 3, 1, 63, 2, 4, 55]
+        expected = [55, 3, 1, 63, 2, 4, 56]
 
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
In this PR I propose two things:

* (Should be invisible for non-gramtools people): Change slightly how the binary PRG string is represented; gramtools represents an A/T snp as 5A6T6 (notice the last char is a 6, not a 5). It was a pain to represent as 5A6T5, I had to run scripts to modify. We might want to have the same representation across pandora and gramtools, but right now the binary string is only used by gramtools anyway i think.

* I propose removing the `-p/--prefix` argument to `from_msa` subcommand, which enabled changing the 'sample name' of the output files, and adding in `-o/--output_dir` and `-n/--prg_name` arguments. I also propose no longer writing out `max_nesting` and `min_match_length` as prefixes to the prg output files. I find this much more intuitive to use. 

  Example: 
  ```make_prg from_msa test.msa -o my_dir -n my_prg``` makes files `my_prg.prg`, `my_prg.gfa` and `my_prg.bin` inside a directory called `my_dir`. The parameters used are available in `my_prg.log` and in the fasta header of `my_prg.prg`. 
  
  Sensible defaults to `-o` and `-n` are provided: `-o` defaults to the directory where the MSA file is, and `-n` to the stem of the MSA filename (here, `test`) 

I'm keen to have discussion going on second point. For eg would it break existing workflows, and do we accept that price for the better usability i find is added here.