### PR TITLE
Provide some options to reduce output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `-L` shortcut for min match length
 - `--log` to enable specifying log file should go to path. Default behaviour is now that
   log goes to stderr by default
-- `--summary` option to specify that user wants a summary file, rather than the default
-  behaviour where they get no choice
 - `-O`, `--output-type` option to specify what output files are required. Defaults to
   all
+
+### Removed
+- summary file
+
 
 ### Changed
 - `--prefix` CLI parameter of `from_msa` subcommand removed in favor of CLI parameters `--outdir`
@@ -51,3 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.1.1]: https://github.com/rmcolq/make_prg/releases/v0.1.1
 [0.1.0]: https://github.com/rmcolq/make_prg/releases/v0.1.0
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `-L` shortcut for min match length
 - `--log` to enable specifying log file should go to path. Default behaviour is now that
   log goes to stderr by default
+- `--summary` option to specify that user wants a summary file, rather than the default
+  behaviour where they get no choice
 
 ### Changed
 - `--prefix` CLI parameter of `from_msa` subcommand removed in favor of CLI parameters `--outdir`
@@ -20,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Output files no longer contain 'max_nesting' and 'min_match_length' in their names; these appear in the log files,
   and in the `.prg` fasta header.
 - `.bin` file now stores even integer markers at site ends; this is the format used by gramtools.
+- Summary file not written by default
 
 ## [0.1.1] - 2021-01-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `-S`, `--seqid` option to name the PRG sequence, which by default uses the file name.
 - `-N` shortcut for max nesting
 - `-L` shortcut for min match length
+- `--log` to enable specifying log file should go to path. Default behaviour is now that
+  log goes to stderr by default
 
 ### Changed
 - `--prefix` CLI parameter of `from_msa` subcommand removed in favor of CLI parameters `--outdir`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `-S`, `--seqid` option to name the PRG sequence, which by default uses the file name.
+- `-N` shortcut for max nesting
+- `-L` shortcut for min match length
+
 ### Changed
 - `--prefix` CLI parameter of `from_msa` subcommand removed in favor of CLI parameters `--outdir`
    and `--prg_name`, with sensible defaults (current working directory and MSA file name stem respectively).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log goes to stderr by default
 - `--summary` option to specify that user wants a summary file, rather than the default
   behaviour where they get no choice
+- `-O`, `--output-type` option to specify what output files are required. Defaults to
+  all
 
 ### Changed
 - `--prefix` CLI parameter of `from_msa` subcommand removed in favor of CLI parameters `--outdir`

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ COPY . /make_prg
 WORKDIR /make_prg
 RUN python3 -m pip install --no-cache-dir .
 # TEST
-RUN python3 -m pip install --no-cache-dir nose hypothesis
+RUN python3 -m pip install --no-cache-dir nose hypothesis pytest
 RUN nosetests -v tests/ && make_prg --help
 # CLEANUP
 WORKDIR /
-RUN python3 -m pip uninstall -y nose hypothesis && \
+RUN python3 -m pip uninstall -y nose hypothesis pytest && \
     apk del .builddeps && \
     rm -rf /root/.cache && \
     rm -rf /make_prg

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,8 @@ RUN python3 -m pip uninstall -y nose hypothesis pytest && \
     rm -rf /root/.cache && \
     rm -rf /make_prg
 
+# so that the use of python uses the python3 in the container
+RUN python3 -m venv /venv
+ENV PATH=/venv/bin:$PATH
+
 CMD ["python3", "-m", "make_prg"]

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ optional arguments:
   -S SEQID, --seqid SEQID
                         Sequence identifier to use for the output sequence/PRG. Default is the file name
   --no_overwrite        Do not replace an existing prg file
-  --summary             Write a summary file
   -O OUTPUT_TYPE, --output-type OUTPUT_TYPE
                         p: PRG, b: Binary, g: GFA, a: All. Combinations are allowed i.e., gb: GFA and Binary. Default: a
   --log LOG             Path to write log to. Default is stderr
 ```
+
 
 ### Nextflow
 
@@ -128,6 +128,7 @@ Requirements: [Nextflow][nf]
 
     Optional arguments:
 ```
+
 
 ## Input
 
@@ -163,3 +164,4 @@ max_forks_make_fasta
 [singularity]: https://sylabs.io/
 [tags]: https://quay.io/repository/iqballab/make_prg?tab=tags
 [conda]: https://conda.io
+

--- a/README.md
+++ b/README.md
@@ -93,22 +93,28 @@ $ make_prg from_msa --help
 usage: make_prg from_msa [options] <MSA input file>
 
 positional arguments:
-  MSA                   Input file: a multiple sequence alignment in supported alignment_format. If not in aligned fasta
-                        alignment_format, use -f to input the alignment_format type
+  MSA                   Input file: a multiple sequence alignment in supported alignment_format. If not in aligned fasta alignment_format, use -f to input
+                        the alignment_format type
 
 optional arguments:
   -h, --help            show this help message and exit
   -f ALIGNMENT_FORMAT, --alignment_format ALIGNMENT_FORMAT
-                        Alignment format of MSA, must be a biopython AlignIO input alignment_format. See
-                        http://biopython.org/wiki/AlignIO. Default: fasta
-  --max_nesting MAX_NESTING
+                        Alignment format of MSA, must be a biopython AlignIO input alignment_format. See http://biopython.org/wiki/AlignIO. Default: fasta
+  -N MAX_NESTING, --max_nesting MAX_NESTING
                         Maximum number of levels to use for nesting. Default: 5
-  --min_match_length MIN_MATCH_LENGTH
+  -L MIN_MATCH_LENGTH, --min_match_length MIN_MATCH_LENGTH
                         Minimum number of consecutive characters which must be identical for a match. Default: 7
-  -p OUTPUT_PREFIX, --prefix OUTPUT_PREFIX
-                        Output prefix
-  --no_overwrite        Do not overwrite pre-existing prg file with same name
-  -v, --verbose         Run with high verbosity (debug level logging)
+  -o OUTPUT_DIR, --outdir OUTPUT_DIR
+                        Output directory. Default: .
+  -n PRG_NAME, --prg_name PRG_NAME
+                        Prg file name. Default: MSA file name
+  -S SEQID, --seqid SEQID
+                        Sequence identifier to use for the output sequence/PRG. Default is the file name
+  --no_overwrite        Do not replace an existing prg file
+  --summary             Write a summary file
+  -O OUTPUT_TYPE, --output-type OUTPUT_TYPE
+                        p: PRG, b: Binary, g: GFA, a: All. Combinations are allowed i.e., gb: GFA and Binary. Default: a
+  --log LOG             Path to write log to. Default is stderr
 ```
 
 ### Nextflow

--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ $ make_prg from_msa --help
 usage: make_prg from_msa [options] <MSA input file>
 
 positional arguments:
-  MSA                   Input file: a multiple sequence alignment in supported alignment_format. If not in aligned fasta alignment_format, use -f to input
-                        the alignment_format type
+  MSA                   Input file: a multiple sequence alignment
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/make_prg/io_utils.py
+++ b/make_prg/io_utils.py
@@ -153,13 +153,16 @@ def write_prg(prg_fname: Path, prg_string: str, options: ArgumentParser):
     Writes it as a human readable string, and also as an integer vector
     """
     seqid = options.seqid or options.prg_name
-    with prg_fname.open("w") as prg:
-        header = f">{seqid} max_nest={options.max_nesting} min_match={options.min_match_length}"
-        print(f"{header}\n{prg_string}", file=prg)
 
-    prg_ints_fpath = prg_fname.with_suffix(".bin")
-    prg_encoder = PrgEncoder()
-    prg_ints: PRG_Ints = prg_encoder.encode(prg_string)
+    if options.output_type.prg:
+        with prg_fname.open("w") as prg:
+            header = f">{seqid} max_nest={options.max_nesting} min_match={options.min_match_length}"
+            print(f"{header}\n{prg_string}", file=prg)
 
-    with prg_ints_fpath.open("wb") as ostream:
-        prg_encoder.write(prg_ints, ostream)
+    if options.output_type.binary:
+        prg_ints_fpath = prg_fname.with_suffix(".bin")
+        prg_encoder = PrgEncoder()
+        prg_ints: PRG_Ints = prg_encoder.encode(prg_string)
+
+        with prg_ints_fpath.open("wb") as ostream:
+            prg_encoder.write(prg_ints, ostream)

--- a/make_prg/io_utils.py
+++ b/make_prg/io_utils.py
@@ -152,8 +152,9 @@ def write_prg(prg_fname: Path, prg_string: str, options: ArgumentParser):
     Writes th prg to `output_file`.
     Writes it as a human readable string, and also as an integer vector
     """
+    seqid = options.seqid or options.prg_name
     with prg_fname.open("w") as prg:
-        header = f">{options.prg_name} max_nest={options.max_nesting} min_match={options.min_match_length}"
+        header = f">{seqid} max_nest={options.max_nesting} min_match={options.min_match_length}"
         print(f"{header}\n{prg_string}", file=prg)
 
     prg_ints_fpath = prg_fname.with_suffix(".bin")

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -80,6 +80,9 @@ def register_parser(subparsers):
         action="store_true",
         help="By default, a prg file which already exists is overwritten and the prg is recomputed. Use this option to keep an existing prg file instead.",
     )
+    subparser_msa.add_argument(
+        "--summary", help="Write a summary file", action="store_true"
+    )
     subparser_msa.add_argument("--log", help="Path to write log to. Default is stderr")
     subparser_msa.set_defaults(func=run)
 
@@ -139,9 +142,10 @@ def run(options):
     logging.info(f"Write GFA file to {gfa_fname}")
     io_utils.write_gfa(gfa_fname, aseq.prg)
 
-    summary_fname = output_dir / "summary.tsv"
-    with summary_fname.open("a") as s:
-        s.write(
-            f"{options.MSA}\t{aseq.site - 2}\t"
-            f"{aseq.max_nesting_level_reached}\t{aseq.prop_in_match_intervals}\n"
-        )
+    if options.summary:
+        summary_fname = output_dir / "summary.tsv"
+        with summary_fname.open("a") as s:
+            s.write(
+                f"{options.MSA}\t{aseq.site - 2}\t"
+                f"{aseq.max_nesting_level_reached}\t{aseq.prop_in_match_intervals}\n"
+            )

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -80,6 +80,7 @@ def register_parser(subparsers):
         action="store_true",
         help="By default, a prg file which already exists is overwritten and the prg is recomputed. Use this option to keep an existing prg file instead.",
     )
+    subparser_msa.add_argument("--log", help="Path to write log to. Default is stderr")
     subparser_msa.set_defaults(func=run)
 
     return subparser_msa
@@ -97,12 +98,12 @@ def run(options):
     ofile_prefix = output_dir / options.prg_name
 
     # Set up file logging
-    log_file = ofile_prefix.with_suffix(".log")
-    log_file.unlink(missing_ok=True)
     formatter = logging.Formatter(
         fmt="%(levelname)s %(asctime)s %(message)s", datefmt="%d/%m/%Y %I:%M:%S"
     )
-    handler = logging.FileHandler(log_file)
+    handler = (
+        logging.FileHandler(options.log) if options.log else logging.StreamHandler()
+    )
     handler.setFormatter(formatter)
     logging.getLogger().addHandler(handler)
 

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -34,6 +34,7 @@ def register_parser(subparsers):
         ),
     )
     subparser_msa.add_argument(
+        "-N",
         "--max_nesting",
         dest="max_nesting",
         action="store",
@@ -42,6 +43,7 @@ def register_parser(subparsers):
         help="Maximum number of levels to use for nesting. Default: %(default)s",
     )
     subparser_msa.add_argument(
+        "-L",
         "--min_match_length",
         dest="min_match_length",
         action="store",
@@ -66,6 +68,11 @@ def register_parser(subparsers):
         dest="prg_name",
         action="store",
         help="Prg file name. Default: MSA file name",
+    )
+    subparser_msa.add_argument(
+        "-S",
+        "--seqid",
+        help="Sequence identifier to use for the output sequence/PRG. Default is the file name",
     )
     subparser_msa.add_argument(
         "--no_overwrite",

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from make_prg.from_msa import prg_builder, NESTING_LVL, MIN_MATCH_LEN
 from make_prg import io_utils
+from make_prg.subcommands.output_type import OutputType
 
 
 def register_parser(subparsers):
@@ -30,7 +31,7 @@ def register_parser(subparsers):
         default="fasta",
         help=(
             "Alignment format of MSA, must be a biopython AlignIO input "
-            "alignment_format. See http://biopython.org/wiki/AlignIO. Default: fasta"
+            "alignment_format. See http://biopython.org/wiki/AlignIO. Default: %(default)s"
         ),
     )
     subparser_msa.add_argument(
@@ -60,7 +61,7 @@ def register_parser(subparsers):
         dest="output_dir",
         action="store",
         default=".",
-        help="Output directory. Default: Current working directory",
+        help="Output directory. Default: %(default)s",
     )
     subparser_msa.add_argument(
         "-n",
@@ -78,10 +79,17 @@ def register_parser(subparsers):
         "--no_overwrite",
         dest="no_overwrite",
         action="store_true",
-        help="By default, a prg file which already exists is overwritten and the prg is recomputed. Use this option to keep an existing prg file instead.",
+        help="Do not replace an existing prg file",
     )
     subparser_msa.add_argument(
         "--summary", help="Write a summary file", action="store_true"
+    )
+    subparser_msa.add_argument(
+        "-O",
+        "--output-type",
+        help="p: PRG, b: Binary, g: GFA, a: All. Combinations are allowed i.e., gb: GFA and Binary. Default: %(default)s",
+        default="a",
+        type=OutputType,
     )
     subparser_msa.add_argument("--log", help="Path to write log to. Default is stderr")
     subparser_msa.set_defaults(func=run)
@@ -138,9 +146,10 @@ def run(options):
         m = aseq.max_nesting_level_reached
         logging.info(f"Max_nesting_reached\t{m}")
 
-    gfa_fname = ofile_prefix.with_suffix(".gfa")
-    logging.info(f"Write GFA file to {gfa_fname}")
-    io_utils.write_gfa(gfa_fname, aseq.prg)
+    if options.output_type.gfa:
+        gfa_fname = ofile_prefix.with_suffix(".gfa")
+        logging.info(f"Write GFA file to {gfa_fname}")
+        io_utils.write_gfa(gfa_fname, aseq.prg)
 
     if options.summary:
         summary_fname = output_dir / "summary.tsv"

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -17,11 +17,7 @@ def register_parser(subparsers):
         "MSA",
         action="store",
         type=str,
-        help=(
-            "Input file: a multiple sequence alignment in supported alignment_format. "
-            "If not in aligned fasta alignment_format, use -f to input the "
-            "alignment_format type"
-        ),
+        help="Input file: a multiple sequence alignment",
     )
     subparser_msa.add_argument(
         "-f",

--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -78,9 +78,6 @@ def register_parser(subparsers):
         help="Do not replace an existing prg file",
     )
     subparser_msa.add_argument(
-        "--summary", help="Write a summary file", action="store_true"
-    )
-    subparser_msa.add_argument(
         "-O",
         "--output-type",
         help="p: PRG, b: Binary, g: GFA, a: All. Combinations are allowed i.e., gb: GFA and Binary. Default: %(default)s",
@@ -147,10 +144,3 @@ def run(options):
         logging.info(f"Write GFA file to {gfa_fname}")
         io_utils.write_gfa(gfa_fname, aseq.prg)
 
-    if options.summary:
-        summary_fname = output_dir / "summary.tsv"
-        with summary_fname.open("a") as s:
-            s.write(
-                f"{options.MSA}\t{aseq.site - 2}\t"
-                f"{aseq.max_nesting_level_reached}\t{aseq.prop_in_match_intervals}\n"
-            )

--- a/make_prg/subcommands/output_type.py
+++ b/make_prg/subcommands/output_type.py
@@ -1,0 +1,33 @@
+class UnknownOutputTypeError(Exception):
+    pass
+
+
+class OutputType:
+    BINARY = "b"
+    ALL = "a"
+    PRG = "p"
+    GFA = "g"
+
+    def __init__(self, value: str):
+        self.type = set(value.lower())
+
+        if not self._any():
+            raise UnknownOutputTypeError(f"{value} is an unknown output type")
+
+    def _any(self) -> bool:
+        return self._all() or self.prg or self.binary or self.gfa
+
+    def _all(self) -> bool:
+        return self.ALL in self.type
+
+    @property
+    def prg(self) -> bool:
+        return self._all() or self.PRG in self.type
+
+    @property
+    def binary(self) -> bool:
+        return self._all() or self.BINARY in self.type
+
+    @property
+    def gfa(self) -> bool:
+        return self._all() or self.GFA in self.type

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     license="MIT",
     entry_points={"console_scripts": ["make_prg = make_prg.__main__:main"]},
     test_suite="nose.collector",
-    tests_require=["nose >= 1.3", "hypothesis >= 4.0"],
+    tests_require=["nose >= 1.3", "hypothesis >= 4.0", "pytest"],
     install_requires=[
         "biopython>=1.70",
         "numpy>=1.14.0",

--- a/tests/test_output_type.py
+++ b/tests/test_output_type.py
@@ -1,0 +1,47 @@
+from make_prg.subcommands.output_type import OutputType, UnknownOutputTypeError
+
+import pytest
+
+
+class TestOutputType:
+    def test_case_insensitive(self):
+        value = "P"
+        otype = OutputType(value)
+
+        assert otype.prg
+
+    def test_unknown_raises_error(self):
+        value = "x"
+
+        with pytest.raises(UnknownOutputTypeError):
+            OutputType(value)
+
+    def test_multiple_types(self):
+        value = "pb"
+        otype = OutputType(value)
+
+        assert otype.prg
+        assert otype.binary
+        assert not otype.gfa
+
+    def test_multiple_with_unknown_and_known_ignores_unknown(self):
+        value = "gqqqq"
+        otype = OutputType(value)
+
+        assert otype.gfa
+
+    def test_all(self):
+        value = "a"
+        otype = OutputType(value)
+
+        assert otype.prg
+        assert otype.binary
+        assert otype.gfa
+
+    def test_all_and_single_ignores_single(self):
+        value = "ap"
+        otype = OutputType(value)
+
+        assert otype.prg
+        assert otype.binary
+        assert otype.gfa


### PR DESCRIPTION
### Added
- `-S`, `--seqid` option to name the PRG sequence, which by default uses the file name.
- `-N` shortcut for max nesting
- `-L` shortcut for min match length
- `--log` to enable specifying log file should go to path. Default behaviour is now that
  log goes to stderr by default
- `--summary` option to specify that user wants a summary file, rather than the default
  behaviour where they get no choice
- `-O`, `--output-type` option to specify what output files are required. Defaults to
  all

### Changed
- Summary file not written by default