### PR TITLE
make_prg update PR series: 4. make_prg update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Multiple Sequence Alignment.
 
 ## Install
 
+### PyPI
+
+```sh
+pip install make_prg
+```
+
 ### Conda
 
 [![Conda (channel only)](https://img.shields.io/conda/vn/bioconda/make_prg)](https://anaconda.org/bioconda/make_prg)

--- a/make_prg/prg_builder.py
+++ b/make_prg/prg_builder.py
@@ -1,3 +1,7 @@
+"""
+This module contains classes to build PRGs from MSAs and manage sets of PRGs
+"""
+
 from typing import Tuple, Dict, Optional, List
 from make_prg.utils.io_utils import load_alignment_file, zip_set_of_files
 import pickle

--- a/make_prg/prg_builder.py
+++ b/make_prg/prg_builder.py
@@ -79,17 +79,17 @@ class PrgBuilder(object):
         self.prg_index.clear()
 
     def get_node_given_interval(self, interval: Tuple[int, int]) -> LeafNode:
+        interval_is_indexed = interval in self.prg_index
+
         # TODO: move this back to assert once is solved
         # TODO: should it really be an assert?
         # TODO: in the pandora paper data, out of 486k update operations, 12 failed with this error
         # TODO: so, there is an edge-case bug here to be solved in next minor versions
-        interval_is_indexed = interval in self.prg_index
         if not interval_is_indexed:
             raise LeafNotFoundException(
                 f"Queried PRG interval {interval} does not exist in PRG index for locus {self.locus_name}.\n"
                 f"Indexed PRG intervals: {self.prg_index.keys()}"
             )
-
         # assert interval in self.prg_index, \
         #     f"Fatal error: Queried interval {interval} does not exist in leaves index for locus {self.locus_name}"
 

--- a/make_prg/prg_builder.py
+++ b/make_prg/prg_builder.py
@@ -1,0 +1,149 @@
+from typing import Tuple, Dict, Optional, List
+from make_prg.utils.io_utils import load_alignment_file, zip_set_of_files
+import pickle
+from pathlib import Path
+from zipfile import ZipFile
+from make_prg.recursion_tree import SingleClusterNode, RecursiveTreeNode
+from make_prg.utils.recursive_tree_drawer import RecursiveTreeDrawer
+from make_prg.utils.prg_encoder import PrgEncoder, PRG_Ints
+import os
+
+
+class LeafNotFoundException(Exception):
+    pass
+
+
+class PrgBuilder(object):
+    """
+    Prg builder based from a multiple sequence alignment.
+    """
+    def __init__(
+        self,
+        locus_name: str,
+        msa_file: Path,
+        alignment_format: str,
+        max_nesting: int,
+        min_match_length: int,
+        aligner: Optional["MSAAligner"] = None,
+    ):
+        self.locus_name: str = locus_name
+        self.max_nesting: int = max_nesting
+        self.min_match_length: int = min_match_length
+        self.aligner: Optional["MSAAligner"] = aligner
+        self.next_node_id: int = 0
+        self.site_num: int = 5
+        self.prg_index: Dict[Tuple[int, int], SingleClusterNode] = {}
+
+        alignment = load_alignment_file(str(msa_file), alignment_format)
+        self.root: RecursiveTreeNode = SingleClusterNode(
+            nesting_level=0,
+            alignment=alignment,
+            parent=None,
+            prg_builder=self
+        )
+
+    def __getstate__(self):
+        """
+        This method is defined so that we don't pickle self.aligner.
+        If we pickle self.aligner, then two PRGs built even with the same aligner, but different temp paths won't be
+        comparable, and we don't actually care about the aligner/temp path that was used, if the rest is the same.
+        """
+        state = self.__dict__.copy()
+        state['aligner'] = None  # force aligner to None
+        return state
+
+    def build_prg(self) -> str:
+        self.site_num = 5
+        prg_as_list = []
+        self.root.preorder_traversal_to_build_prg(prg_as_list)
+        prg = "".join(prg_as_list)
+        return prg
+
+    def get_next_site_num(self) -> int:
+        site_num = self.site_num
+        self.site_num += 2
+        return site_num
+
+    def get_next_node_id(self) -> int:
+        self.next_node_id += 1
+        return self.next_node_id - 1
+
+    def update_PRG_index(self, start_index: int, end_index: int, node: SingleClusterNode):
+        interval = (start_index, end_index)
+        self.prg_index[interval] = node
+        node.add_indexed_PRG_interval(interval)
+
+    def get_node_given_interval(self, interval: Tuple[int, int]) -> SingleClusterNode:
+        # TODO: move this back to assert once is solved
+        # TODO: should it really be an assert?
+        # TODO: in the pandora paper data, out of 486k update operations, 12 failed with this error
+        # TODO: so, there is an edge-case bug here to be solved in next minor versions
+        interval_is_indexed = interval in self.prg_index
+        if not interval_is_indexed:
+            raise LeafNotFoundException(
+                f"Queried PRG interval {interval} does not exist in PRG index for locus {self.locus_name}.\n"
+                f"Indexed PRG intervals: {self.prg_index.keys()}"
+            )
+
+        # assert interval in self.prg_index, \
+        #     f"Fatal error: Queried interval {interval} does not exist in leaves index for locus {self.locus_name}"
+
+        return self.prg_index[interval]
+
+    def serialize(self, filepath: [Path, str]):
+        with open(filepath, "wb") as filehandler:
+            pickle.dump(self, filehandler)
+
+    @staticmethod
+    def deserialize_from_bytes(array_of_bytes: bytes) -> "PrgBuilder":
+        return pickle.loads(array_of_bytes)
+
+    @staticmethod
+    def write_prg_as_text(output_prefix: str, prg_string: str):
+        sample = Path(output_prefix).name
+        prg_filename = Path(output_prefix + ".prg.fa")
+        with prg_filename.open("w") as prg:
+            print(f">{sample}\n{prg_string}", file=prg)
+
+    @staticmethod
+    def write_prg_as_binary(output_prefix: str, prg_string: str):
+        prg_ints_fpath = Path(output_prefix + ".bin")
+        prg_encoder = PrgEncoder()
+        prg_ints: PRG_Ints = prg_encoder.encode(prg_string)
+        with prg_ints_fpath.open("wb") as ostream:
+            prg_encoder.write(prg_ints, ostream)
+
+    def output_debug_graphs(self, debug_graphs_dir: Path):
+        os.makedirs(debug_graphs_dir, exist_ok=True)
+        recursive_tree_drawer = RecursiveTreeDrawer(self.root)
+        recursive_tree_drawer.output_graph(debug_graphs_dir / f"{self.locus_name}.recursion_tree.png")
+
+
+class PrgBuilderZipDatabase:
+    """
+    Represent a collection of PrgBuilders, to be saved to and loaded from a zip file
+    """
+    def __init__(self, zip_filepath: Path):
+        is_a_zip_file = zip_filepath.suffix == ".zip"
+        assert is_a_zip_file, "PrgBuilderZipDatabase initialised without a .zip filepath"
+        self._zip_filepath: Path = zip_filepath
+        self._zip_file: Optional[ZipFile] = None
+
+    def save(self, locus_to_prg_builder_pickle_path: Dict[str, Path]):
+        zip_set_of_files(self._zip_filepath, locus_to_prg_builder_pickle_path)
+
+    def load(self):
+        self._zip_file = ZipFile(self._zip_filepath)
+
+    def close(self):
+        if self._zip_file is not None:
+            self._zip_file.close()
+
+    def get_number_of_loci(self) -> int:
+        return len(self.get_loci_names())
+
+    def get_loci_names(self) -> List[str]:
+        return self._zip_file.namelist()
+
+    def get_PrgBuilder(self, locus: str) -> PrgBuilder:
+        return PrgBuilder.deserialize_from_bytes(self._zip_file.read(locus))

--- a/make_prg/recursion_tree.py
+++ b/make_prg/recursion_tree.py
@@ -1,7 +1,11 @@
+"""
+This module contains the classes to explicitly represent the make_prg process recursion tree
+"""
+
 from typing import List, Set, Optional, Tuple
 from loguru import logger
 from make_prg.from_msa import MSA
-from make_prg.from_msa.cluster_sequences import kmeans_cluster_seqs
+from make_prg.from_msa.cluster_sequences import kmeans_cluster_seqs, ClusteringResult
 from make_prg.utils.seq_utils import (
     SequenceExpander,
     remove_columns_full_of_gaps_from_MSA,
@@ -9,89 +13,32 @@ from make_prg.utils.seq_utils import (
     get_number_of_unique_ungapped_sequences,
     get_number_of_unique_gapped_sequences
 )
-from make_prg.from_msa.interval_partition import IntervalPartitioner, Interval
+from make_prg.from_msa.interval_partition import IntervalPartitioner, Interval, Intervals
 from make_prg.update.denovo_variants import UpdateData
 from make_prg.update.MLPath import MLPathError
 from abc import ABC, abstractmethod
 
-SubMSAs: List[MSA]
+SubMSAs = List[MSA]
 
-
-class PrgNode(ABC):
-    @abstractmethod
-    def get_prg(self):
-        pass
-
-class MultiIntervalNode(PrgNode):
-    def __init__(self, vertical_clusters: SubMSAs):
-        for interval in intervals:
-            self.children.append(NodeFactory.build(sub_MSA, skip_intervals = True))
-
-    def get_prg(self):
-        site = ""
-        for child in self.children:
-            site += child.get_prg()
-        return site
-
-class MultiClusterNode(PrgNode):
-    def __init__(self, horizontal_clusters: SubMSAs):
-        for hori_cluster in horizontal_clusters:
-            self.children.append(NodeFactory.build(sub_MSA, skip_clustering = True))
-
-    def get_prg():
-        site = open_site()
-        for child in self.children:
-            # add each allele
-            site += child.get_prg()
-            site += allele_delim
-        return site
-
-class Leaf(PrgNode):
-    def __init__(self, MSA: MSA):
-        if only_one_seq(MSA):
-            self.prg = MSA[0]
-        else:
-            # make a set of alleles
-            self.prg = make_allele_set(MSA)
-    def get_prg():
-        return self.prg
-
-
-class NodeFactory:
-    @staticmethod
-    def build(MSA, skip_intervals: bool = False, skip_clustering: bool = False):
-        # Or: pass in `parent`, that is a `PrgNode`, and determine whether or not to
-        # skip interval/clustering based on parent class type. Also allows forwarding
-        # attributes like `nesting_level` to constructors
-        assert not all([skip_intervals, skip_clustering])
-        if not skip_intervals and has_intervals(MSA):
-            vertical_clusters: SubMSAs = get_intervals()
-            return MultiIntervalNode(vertical_clusters)
-        # has_clusters should check the clustering_result to see if there was a
-        # clustering
-        elif not skip_clustering and has_clusters(MSA):
-            horizontal_clusters: SubMSAs = get_clusters()
-            return MultiClusterNode(clusters)
-        else:
-            return Leaf()
-
-# In main():
-root = NodeFactory(MSA) # Creates the whole tree
-prg = root.get_prg() # Pre_order traversal producing the prg string
 
 class RecursiveTreeNode(ABC):
-    def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
-                 prg_builder: "PrgBuilder", force_no_child: bool = False):
+    def __init__(self, nesting_level: int, alignment: MSA,
+                 parent: Optional["RecursiveTreeNode"], prg_builder: "PrgBuilder",
+                 children_subalignments: SubMSAs):
+        """
+        Builds a new recursive tree node.
+        Notes:
+            1. To build a node you need to know in advance how it is going to cluster (horizontally or vertically).
+                This is given in the children_subalignments param. NodeFactory.build() takes care of this (see below).
+        """
         self.nesting_level: int = nesting_level
         self.alignment: MSA = remove_columns_full_of_gaps_from_MSA(alignment)
-        self.parent: "RecursiveTreeNode" = parent
-        self.prg_builder: "PrgBuilder" = prg_builder
-        self.force_no_child = force_no_child
+        self.parent: Optional["RecursiveTreeNode"] = parent
+        self.prg_builder = prg_builder
         self.id: int = self.prg_builder.get_next_node_id()
 
         # generate recursion tree
-        self._init_pre_recursion_attributes()
-        self._children: List["RecursiveTreeNode"] = self._get_children()
+        self._children: List["RecursiveTreeNode"] = self._get_children(children_subalignments)
 
         self.log_that_node_was_created()
 
@@ -99,13 +46,8 @@ class RecursiveTreeNode(ABC):
     def children(self):
         return self._children
 
-    @abstractmethod
-    def _init_pre_recursion_attributes(self):
-        pass
-
-    @abstractmethod
-    def _get_children(self) -> List["RecursiveTreeNode"]:
-        pass
+    def _get_children(self, children_subalignments: SubMSAs) -> List["RecursiveTreeNode"]:
+        return [NodeFactory.build(alignment, self.prg_builder, self) for alignment in children_subalignments]
 
     @abstractmethod
     def preorder_traversal_to_build_prg(self, prg_as_list: List[str], delim_char: str = " "):
@@ -117,48 +59,52 @@ class RecursiveTreeNode(ABC):
     def is_root(self) -> bool:
         return self.parent is None
 
+    def replace_child(self, old_child: "RecursiveTreeNode", new_child: "RecursiveTreeNode"):
+        old_child_is_one_of_the_children = old_child in self.children
+        assert old_child_is_one_of_the_children, f"Failure to replace a child, {old_child} does not exist"
+
+        old_child_index = self.children.index(old_child)
+        self.children[old_child_index] = new_child
+
+    # Note: trivial method, untested
     def log_that_node_was_created(self):
         logger.trace("Created node:\n" + str(self))
 
     def __repr__(self):
-        return f"Id = {self.id}\n" \
+        return f"{self.__class__.__name__}:\n" \
+               f"Id = {self.id}\n" \
                f"Nesting level = {self.nesting_level}\n" \
-               f"Force no child = {self.force_no_child}\n" \
                f"Parent = {'None' if self.parent is None else f'Id = {self.parent.id}'}\n" \
-               f"Children = [{', '.join([f'Id = {child.id}' for child in self.children])}]\n" \
+               f"Children = [{', '.join(f'Id = {child.id}' for child in self.children)}]\n" \
                f"Alignment:\n{format(self.alignment, 'fasta')}"
 
     def __str__(self):
         return repr(self)
 
 
-class MultiClusterNode(RecursiveTreeNode):
+class MultiIntervalNode(RecursiveTreeNode):
+    """
+    Represent nodes that are clustered vertically, i.e. in intervals
+    """
     def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
-                 prg_builder: "PrgBuilder", force_no_child: bool = False):
-        super().__init__(nesting_level, alignment, parent, prg_builder, force_no_child)
-        assert not self.is_leaf(), "Multicluster nodes should never be leaves"
+                 prg_builder: "PrgBuilder", interval_subalignments: SubMSAs):
+        super().__init__(nesting_level, alignment, parent, prg_builder, interval_subalignments)
+        assert not self.is_leaf(), "MultiIntervalNodes should never be leaves"
 
-    def _init_pre_recursion_attributes(self):
-        pass  # nothing to init here
+    def preorder_traversal_to_build_prg(self, prg_as_list: List[str], delim_char: str = " "):
+        for child in self.children:
+            child.preorder_traversal_to_build_prg(prg_as_list, delim_char)
 
-    def _get_children(self) -> List["RecursiveTreeNode"]:
-        # each child is a PrgBuilderSingleClusterNode for each cluster subalignment
-        cluster_subalignments = self._get_subalignments_by_clustering()
-        no_clustering_was_done = len(cluster_subalignments) == 1
-        children = []
-        for alignment in cluster_subalignments:
-            child = SingleClusterNode(
-                nesting_level=self.nesting_level,
-                alignment=alignment,
-                parent=self,
-                prg_builder=self.prg_builder,
-                force_no_child=no_clustering_was_done
-            )
-            children.append(child)
-        return children
 
-    ##################################################################################
-    # traversal methods
+class MultiClusterNode(RecursiveTreeNode):
+    """
+    Represent nodes that are clustered horizontally, i.e. in sequence clusters
+    """
+    def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
+                 prg_builder: "PrgBuilder", cluster_subalignments: SubMSAs):
+        super().__init__(nesting_level, alignment, parent, prg_builder, cluster_subalignments)
+        assert not self.is_leaf(), "MultiClusterNodes should never be leaves"
+
     def preorder_traversal_to_build_prg(self, prg_as_list: List[str], delim_char: str = " "):
         site_num = self.prg_builder.get_next_site_num()
         prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
@@ -171,184 +117,53 @@ class MultiClusterNode(RecursiveTreeNode):
             prg_as_list.extend(
                 f"{delim_char}{site_num_to_separate_alleles}{delim_char}"
             )
-    ##################################################################################
-
-    #####################################################################################################
-    #  clustering methods
-    def _get_subalignments_by_clustering(self) -> List[MSA]:
-        clustering_result = kmeans_cluster_seqs(
-            self.alignment,
-            self.prg_builder.min_match_length
-        )
-        list_sub_alignments = [
-            self._get_sub_alignment_by_list_id(clustered_id) for clustered_id in clustering_result.clustered_ids
-        ]
-        return list_sub_alignments
-
-    def _get_sub_alignment_by_list_id(self, id_list: List[str]) -> MSA:
-        list_records = [record for record in self.alignment if record.id in id_list]
-        sub_alignment = MSA(list_records)
-        return sub_alignment
-    #####################################################################################################
-
-    def __repr__(self):
-        return "MultiClusterNode:\n" + super().__repr__()
 
 
 class UpdateError(Exception):
     pass
 
 
-class SingleClusterNode(RecursiveTreeNode):
-    def _init_pre_recursion_attributes(self):
-        self.consensus: str = get_consensus_from_MSA(self.alignment)
-        self.length: int = len(self.consensus)
-        interval_partitioner = IntervalPartitioner(self.consensus, self.prg_builder.min_match_length, self.alignment)
-        (
-            self.match_intervals,
-            self.non_match_intervals,
-            self.all_intervals,
-        ) = interval_partitioner.get_intervals()
+class LeafNode(RecursiveTreeNode):
+    """
+    Represent nodes that are never clustered in either direction.
+    These nodes are the only ones that can get updated and indexed.
+    """
+    def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
+                 prg_builder: "PrgBuilder"):
+        super().__init__(nesting_level, alignment, parent, prg_builder, [])
+        assert self.is_leaf(), f"Leaf node ({self}) is not a leaf"
         self.new_sequences: Set[str] = set()
         self.indexed_PRG_intervals: Set[Tuple[int, int]] = set()
 
-    @staticmethod
-    def _alignment_has_issues(alignment: MSA) -> bool:
-        num_unique_nongapped_seqs = get_number_of_unique_ungapped_sequences(alignment)
-        too_few_unique_sequences = num_unique_nongapped_seqs <= 2
-        if too_few_unique_sequences:
-            return True
+    def preorder_traversal_to_build_prg(self, prg_as_list: List[str], delim_char: str = " ", do_indexing=True):
+        # Note: here we could have several intervals, not anymore
+        expanded_sequences = SequenceExpander.get_expanded_sequences_from_MSA(self.alignment)
 
-        num_unique_gapped_seqs = get_number_of_unique_gapped_sequences(alignment)
-
-        # this is an assert as if it happens, something very wrong with the two previous functions is happening
-        assert num_unique_nongapped_seqs <= num_unique_gapped_seqs
-
-        alignment_has_ambiguity = num_unique_nongapped_seqs < num_unique_gapped_seqs
-        if alignment_has_ambiguity:
-            # TODO: fix alignment by deduplicating nongapped seqs and realigning them
-            # TODO: the annoying thing is that this deduplicated nongapped alignment will differ from the input alignment
-            # TODO: but I think it can be an ok solution
-            return True
-
-        return False
-
-    def _infer_if_this_node_should_have_no_child(self) -> bool:
-        if self.force_no_child:
-            return True
-
-        single_match_interval = (len(self.all_intervals) == 1) and (
-                self.all_intervals[0] in self.match_intervals
-        )
-        if single_match_interval:
-            return True
-
-        max_nesting_level_reached = self.nesting_level == self.prg_builder.max_nesting
-        if max_nesting_level_reached:
-            return True
-
-        small_variant_site = self.alignment.get_alignment_length() < self.prg_builder.min_match_length
-        if small_variant_site:
-            return True
-
-        # TODO: this could be computationally optimised (time performance) by receiving this bool variable by
-        # TODO: parameter in the constructor, and not recomputing it here. But I think we lose code readability,
-        # TODO: maintenability and introduce an annoying dependence... But something to think about if we want to push
-        # TODO: performance
-        alignment_has_issues = self._alignment_has_issues(self.alignment)
-        if alignment_has_issues:
-            return True
-
-        return False
-
-    def _infer_if_should_not_cluster(self, interval: Interval, alignment: MSA):
-        is_a_match_interval = interval in self.match_intervals
-        if is_a_match_interval:
-            return True
-
-        alignment_has_issues = self._alignment_has_issues(self.alignment)
-        if alignment_has_issues:
-            return True
-
-        clustering_result = kmeans_cluster_seqs(alignment, self.prg_builder.min_match_length)
-        if clustering_result.no_clustering:
-            return True
-
-        return False
-
-    def _get_children(self) -> List["RecursiveTreeNode"]:
-        node_has_no_child = self._infer_if_this_node_should_have_no_child()
-        if node_has_no_child:
-            return list()
-
-        children = []
-        for interval in self.all_intervals:
-            sub_alignment = self.alignment[:, interval.start : interval.stop + 1]
-            sub_alignment_will_not_be_reclustered = self._infer_if_should_not_cluster(interval, sub_alignment)
-            if sub_alignment_will_not_be_reclustered:
-                subclass = SingleClusterNode
-            else:
-                subclass = MultiClusterNode
-            child = subclass(
-                nesting_level=self.nesting_level + 1,
-                alignment=sub_alignment,
-                parent=self,
-                prg_builder=self.prg_builder,
-                force_no_child=sub_alignment_will_not_be_reclustered
-            )
-            children.append(child)
-
-        return children
-
-    def _get_prg(self, prg_as_list: List[str], delim_char: str = " "):
-        sequences_can_be_obtained_directly_from_clustering = False
-        if not self.is_root():
-            clustering_result = kmeans_cluster_seqs(self.alignment, self.prg_builder.min_match_length)
-            sequences_can_be_obtained_directly_from_clustering = clustering_result.have_precomputed_sequences
-
-        sequences_of_each_interval = []
-        if sequences_can_be_obtained_directly_from_clustering:
-            sequences_of_each_interval.append(clustering_result.sequences)
-        else:
-            for interval in self.all_intervals:
-                sub_alignment = self.alignment[:, interval.start:interval.stop + 1]
-                seqs = SequenceExpander.get_expanded_sequences_from_MSA(sub_alignment)
-                sequences_of_each_interval.append(seqs)
-
-        for sequences_of_this_interval in sequences_of_each_interval:
-            single_seq = len(sequences_of_this_interval) == 1
-            if single_seq:
-                start_index = len(prg_as_list)
-                prg_as_list.extend(sequences_of_this_interval[0])
-                end_index = len(prg_as_list)
+        single_seq = len(expanded_sequences) == 1
+        if single_seq:
+            start_index = len(prg_as_list)
+            prg_as_list.extend(expanded_sequences[0])
+            end_index = len(prg_as_list)
+            if do_indexing:
                 self.prg_builder.update_PRG_index(start_index, end_index, node=self)
-            else:
-                # Add the variant seqs to the prg
-                site_num = self.prg_builder.get_next_site_num()
-                prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
-                for seq_index, seq in enumerate(sequences_of_this_interval):
-                    site_num_for_this_seq = (
-                        (site_num + 1) if (seq_index < len(sequences_of_this_interval) - 1) else site_num
-                    )
-                    start_index = len(prg_as_list)
-                    prg_as_list.extend(seq)
-                    end_index = len(prg_as_list)
-                    self.prg_builder.update_PRG_index(
-                        start_index, end_index, node=self
-                    )
-                    prg_as_list.extend(
-                        f"{delim_char}{site_num_for_this_seq}{delim_char}"
-                    )
-
-    ##################################################################################
-    # traversal methods
-    def preorder_traversal_to_build_prg(self, prg_as_list: List["str"], delim_char: str = " "):
-        if self.is_leaf():
-            self._get_prg(prg_as_list, delim_char)
         else:
-            for child in self.children:
-                child.preorder_traversal_to_build_prg(prg_as_list, delim_char)
-    ##################################################################################
+            # Add the variant seqs to the prg
+            site_num = self.prg_builder.get_next_site_num()
+            prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
+            for seq_index, seq in enumerate(expanded_sequences):
+                site_num_for_this_seq = (
+                    (site_num + 1) if (seq_index < len(expanded_sequences) - 1) else site_num
+                )
+                start_index = len(prg_as_list)
+                prg_as_list.extend(seq)
+                end_index = len(prg_as_list)
+
+                prg_as_list.extend(
+                    f"{delim_char}{site_num_for_this_seq}{delim_char}"
+                )
+
+                if do_indexing:
+                    self.prg_builder.update_PRG_index(start_index, end_index, node=self)
 
     ##################################################################################
     # update methods
@@ -370,7 +185,6 @@ class SingleClusterNode(RecursiveTreeNode):
                     seq_to_add_as_list.append(ml_path_node.sequence)
                 except MLPathError:
                     pass
-
         seq_to_add = "".join(seq_to_add_as_list)
 
         there_has_been_padding = seq_to_add != update_data.new_node_sequence
@@ -390,25 +204,181 @@ class SingleClusterNode(RecursiveTreeNode):
         self._update_leaf()
 
     def _update_leaf(self):
-        logger.trace(f"Updating MSA for {self.prg_builder.locus_name}")
+        logger.trace(f"Updating subMSA for {self.prg_builder.locus_name}")
         logger.trace(f"Node: {str(self)}")
         logger.trace(f"Sequences added to update: {self.new_sequences}")
 
         an_aligner_was_given = self.prg_builder.aligner is not None
         assert an_aligner_was_given, "Cannot make updates without a Multiple Sequence Aligner."
 
-        self.alignment = self.prg_builder.aligner.get_updated_alignment(
+        updated_alignment = self.prg_builder.aligner.get_updated_alignment(
             current_alignment=self.alignment,
             new_sequences=self.new_sequences
         )
 
-        # regenerate recursion tree
-        self._init_pre_recursion_attributes()
-        self._children = self._get_children()
+        # create a new, updated node, and add it to the tree
+        updated_child = NodeFactory.build(updated_alignment, self.prg_builder, self.parent)
+
+        # in some cases, we might have just a single node, which is both the root and a leaf
+        need_to_replace_the_root = self.is_root()
+        if need_to_replace_the_root:
+            self.prg_builder.replace_root(updated_child)
+        else:
+            self.parent.replace_child(self, updated_child)
+
+        # whenever we do an update in a node, we will mess up the prg builder index for the sites to the right of the
+        # updated site in the PRG string. Just to be safe, we clear the prg index, as it will be regenerated again
+        # when rebuilding the PRG
+        self.prg_builder.clear_PRG_index()
+
+    def clear_PRG_interval_index(self):
+        self.indexed_PRG_intervals.clear()
     ##################################################################################
 
-    def __repr__(self):
-        return "SingleClusterNode:\n" + RecursiveTreeNode.__repr__(self) + \
-               f"Consensus: {self.consensus}\n" \
-               f"Match intervals: {self.match_intervals}\n" \
-               f"Non-match intervals: {self.non_match_intervals}\n"
+
+class NodeFactory:
+    """
+    Class responsible to build the different RecursiveTreeNodes depending on its alignment and other parameters.
+    """
+    @staticmethod
+    def build(alignment: MSA, prg_builder: "PrgBuilder", parent_node: Optional[RecursiveTreeNode] = None) -> RecursiveTreeNode:
+        """
+        Method that builds the correct node given the alignment and other parameters.
+        Note that the root has a None parent. For the root also, we need to first try to build a MultiIntervalNode and
+        then a MulticlusterNode,as we first want to split its intervals, and then cluster.
+        """
+        parent_node_is_leaf = isinstance(parent_node, LeafNode)
+        assert not parent_node_is_leaf, "Error on building a Recursive Tree node: parent node should never be a leaf"
+
+        min_match_length = prg_builder.min_match_length
+        nesting_level = NodeFactory._get_nesting_level(parent_node)
+
+        # if parent is multi interval, children should not be
+        skip_building_multi_interval_node = isinstance(parent_node, MultiIntervalNode)
+        if not skip_building_multi_interval_node:
+            all_intervals, match_intervals = NodeFactory._get_all_and_match_intervals(alignment, min_match_length)
+
+            has_a_single_interval = NodeFactory._infer_if_has_single_interval(all_intervals=all_intervals, match_intervals=match_intervals,
+                                                                nesting_level=nesting_level,
+                                                                max_nesting=prg_builder.max_nesting,
+                                                                alignment=alignment,
+                                                                min_match_length=min_match_length)
+
+            if not has_a_single_interval:
+                interval_subalignments = NodeFactory._partition_alignment_into_interval_subalignments(alignment,
+                                                                                                      all_intervals)
+                return MultiIntervalNode(nesting_level, alignment, parent_node, prg_builder, interval_subalignments)
+
+        # if parent is multi cluster, children should not be
+        skip_building_multi_cluster_node = isinstance(parent_node, MultiClusterNode)
+        if not skip_building_multi_cluster_node:
+            clustering_result = kmeans_cluster_seqs(alignment, min_match_length)
+            cluster_further = NodeFactory._infer_if_we_should_cluster_further(alignment, clustering_result)
+
+            if cluster_further:
+                cluster_subalignments = NodeFactory._get_subalignments_by_clustering(alignment, clustering_result)
+                return MultiClusterNode(nesting_level, alignment, parent_node, prg_builder,
+                                        cluster_subalignments)
+
+        # here the node is a leaf
+        return LeafNode(nesting_level, alignment, parent_node, prg_builder)
+
+    #####################################################################################################
+    #  helper methods
+    @staticmethod
+    def _alignment_has_issues(alignment: MSA) -> bool:
+        num_unique_nongapped_seqs = get_number_of_unique_ungapped_sequences(alignment)
+        too_few_unique_sequences = num_unique_nongapped_seqs <= 2
+        if too_few_unique_sequences:
+            return True
+
+        num_unique_gapped_seqs = get_number_of_unique_gapped_sequences(alignment)
+
+        # this is an assert as if it happens, something very wrong with the two previous functions is happening
+        assert num_unique_nongapped_seqs <= num_unique_gapped_seqs
+
+        alignment_has_ambiguity = num_unique_nongapped_seqs < num_unique_gapped_seqs
+        if alignment_has_ambiguity:
+            # TODO: fix alignment by deduplicating nongapped seqs and realigning them
+            # TODO: the annoying thing is that this deduplicated nongapped alignment will differ from the input alignment
+            # TODO: but I think it can be an ok solution
+            return True
+
+        return False
+
+    @staticmethod
+    def _get_nesting_level(parent_node: Optional[RecursiveTreeNode]) -> int:
+        is_root = parent_node is None
+        if is_root:
+            nesting_level = 0
+        else:
+            need_to_go_down_one_level = isinstance(parent_node, MultiClusterNode)
+            if need_to_go_down_one_level:
+                nesting_level = parent_node.nesting_level + 1
+            else:
+                nesting_level = parent_node.nesting_level
+        return nesting_level
+    #####################################################################################################
+
+    #####################################################################################################
+    #  interval methods
+    @staticmethod
+    def _infer_if_has_single_interval(all_intervals: Intervals, match_intervals: Intervals,
+                                      nesting_level: int, max_nesting: int,
+                                      alignment: MSA, min_match_length: int) -> bool:
+        single_match_interval = (len(all_intervals) == 1) and (all_intervals[0] in match_intervals)
+        if single_match_interval:
+            return True
+
+        max_nesting_level_reached = nesting_level == max_nesting
+        if max_nesting_level_reached:
+            return True
+
+        small_variant_site = alignment.get_alignment_length() < min_match_length
+        if small_variant_site:
+            return True
+
+        return False
+
+    @staticmethod
+    def _get_all_and_match_intervals(alignment: MSA, min_match_length: int) -> Tuple[Intervals, Intervals]:
+        consensus = get_consensus_from_MSA(alignment)
+        interval_partitioner = IntervalPartitioner(consensus, min_match_length, alignment)
+        (
+            match_intervals,
+            non_match_intervals,
+            all_intervals,
+        ) = interval_partitioner.get_intervals()
+        return all_intervals, match_intervals
+
+    @staticmethod
+    def _partition_alignment_into_interval_subalignments(alignment: MSA, all_intervals: Intervals) -> List[MSA]:
+        return [alignment[:, interval.start: interval.stop + 1] for interval in all_intervals]
+    #####################################################################################################
+
+    #####################################################################################################
+    #  clustering methods
+    @staticmethod
+    def _infer_if_we_should_cluster_further(alignment: MSA, clustering_result: ClusteringResult) -> bool:
+        if clustering_result.no_clustering:
+            return False
+
+        alignment_has_issues = NodeFactory._alignment_has_issues(alignment)
+        if alignment_has_issues:
+            return False
+
+        return True
+
+    @staticmethod
+    def _get_subalignments_by_clustering(alignment: MSA, clustering_result: ClusteringResult) -> SubMSAs:
+        list_sub_alignments = [
+            NodeFactory._get_sub_alignment_by_list_id(alignment, clustered_id) for clustered_id in clustering_result.clustered_ids
+        ]
+        return list_sub_alignments
+
+    @staticmethod
+    def _get_sub_alignment_by_list_id(alignment: MSA, id_list: List[str]) -> MSA:
+        list_records = [record for record in alignment if record.id in id_list]
+        sub_alignment = MSA(list_records)
+        return sub_alignment
+    #####################################################################################################

--- a/make_prg/recursion_tree.py
+++ b/make_prg/recursion_tree.py
@@ -1,0 +1,350 @@
+from typing import List, Set, Optional, Tuple
+from loguru import logger
+from make_prg.from_msa import MSA
+from make_prg.from_msa.cluster_sequences import kmeans_cluster_seqs
+from make_prg.utils.seq_utils import (
+    SequenceExpander,
+    remove_columns_full_of_gaps_from_MSA,
+    get_consensus_from_MSA,
+    get_number_of_unique_ungapped_sequences,
+    get_number_of_unique_gapped_sequences
+)
+from make_prg.from_msa.interval_partition import IntervalPartitioner, Interval
+from make_prg.update.denovo_variants import UpdateData
+from make_prg.update.MLPath import MLPathError
+from abc import ABC, abstractmethod
+
+
+class RecursiveTreeNode(ABC):
+    def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
+                 prg_builder: "PrgBuilder", force_no_child: bool = False):
+        self.nesting_level: int = nesting_level
+        self.alignment: MSA = remove_columns_full_of_gaps_from_MSA(alignment)
+        self.parent: "RecursiveTreeNode" = parent
+        self.prg_builder: "PrgBuilder" = prg_builder
+        self.force_no_child = force_no_child
+        self.id: int = self.prg_builder.get_next_node_id()
+
+        # generate recursion tree
+        self._init_pre_recursion_attributes()
+        self._children: List["RecursiveTreeNode"] = self._get_children()
+
+        self.log_that_node_was_created()
+
+    @property
+    def children(self):
+        return self._children
+
+    @abstractmethod
+    def _init_pre_recursion_attributes(self):
+        pass
+
+    @abstractmethod
+    def _get_children(self) -> List["RecursiveTreeNode"]:
+        pass
+
+    @abstractmethod
+    def preorder_traversal_to_build_prg(self, prg_as_list: List[str], delim_char: str = " "):
+        pass
+
+    def is_leaf(self) -> bool:
+        return len(self.children) == 0
+
+    def is_root(self) -> bool:
+        return self.parent is None
+
+    def log_that_node_was_created(self):
+        logger.trace("Created node:\n" + str(self))
+
+    def __repr__(self):
+        return f"Id = {self.id}\n" \
+               f"Nesting level = {self.nesting_level}\n" \
+               f"Force no child = {self.force_no_child}\n" \
+               f"Parent = {'None' if self.parent is None else f'Id = {self.parent.id}'}\n" \
+               f"Children = [{', '.join([f'Id = {child.id}' for child in self.children])}]\n" \
+               f"Alignment:\n{format(self.alignment, 'fasta')}"
+
+    def __str__(self):
+        return repr(self)
+
+
+class MultiClusterNode(RecursiveTreeNode):
+    def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
+                 prg_builder: "PrgBuilder", force_no_child: bool = False):
+        super().__init__(nesting_level, alignment, parent, prg_builder, force_no_child)
+        assert not self.is_leaf(), "Multicluster nodes should never be leaves"
+
+    def _init_pre_recursion_attributes(self):
+        pass  # nothing to init here
+
+    def _get_children(self) -> List["RecursiveTreeNode"]:
+        # each child is a PrgBuilderSingleClusterNode for each cluster subalignment
+        cluster_subalignments = self._get_subalignments_by_clustering()
+        no_clustering_was_done = len(cluster_subalignments) == 1
+        children = []
+        for alignment in cluster_subalignments:
+            child = SingleClusterNode(
+                nesting_level=self.nesting_level,
+                alignment=alignment,
+                parent=self,
+                prg_builder=self.prg_builder,
+                force_no_child=no_clustering_was_done
+            )
+            children.append(child)
+        return children
+
+    ##################################################################################
+    # traversal methods
+    def preorder_traversal_to_build_prg(self, prg_as_list: List[str], delim_char: str = " "):
+        site_num = self.prg_builder.get_next_site_num()
+        prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
+
+        for child_index, child in enumerate(self.children):
+            site_num_to_separate_alleles = (
+                (site_num + 1) if (child_index < len(self.children) - 1) else site_num
+            )
+            child.preorder_traversal_to_build_prg(prg_as_list, delim_char)
+            prg_as_list.extend(
+                f"{delim_char}{site_num_to_separate_alleles}{delim_char}"
+            )
+    ##################################################################################
+
+    #####################################################################################################
+    #  clustering methods
+    def _get_subalignments_by_clustering(self) -> List[MSA]:
+        clustering_result = kmeans_cluster_seqs(
+            self.alignment,
+            self.prg_builder.min_match_length
+        )
+        list_sub_alignments = [
+            self._get_sub_alignment_by_list_id(clustered_id) for clustered_id in clustering_result.clustered_ids
+        ]
+        return list_sub_alignments
+
+    def _get_sub_alignment_by_list_id(self, id_list: List[str]) -> MSA:
+        list_records = [record for record in self.alignment if record.id in id_list]
+        sub_alignment = MSA(list_records)
+        return sub_alignment
+    #####################################################################################################
+
+    def __repr__(self):
+        return "MultiClusterNode:\n" + super().__repr__()
+
+
+class UpdateError(Exception):
+    pass
+
+
+class SingleClusterNode(RecursiveTreeNode):
+    def _init_pre_recursion_attributes(self):
+        self.consensus: str = get_consensus_from_MSA(self.alignment)
+        self.length: int = len(self.consensus)
+        interval_partitioner = IntervalPartitioner(self.consensus, self.prg_builder.min_match_length, self.alignment)
+        (
+            self.match_intervals,
+            self.non_match_intervals,
+            self.all_intervals,
+        ) = interval_partitioner.get_intervals()
+        self.new_sequences: Set[str] = set()
+        self.indexed_PRG_intervals: Set[Tuple[int, int]] = set()
+
+    @staticmethod
+    def _alignment_has_issues(alignment: MSA) -> bool:
+        num_unique_nongapped_seqs = get_number_of_unique_ungapped_sequences(alignment)
+        too_few_unique_sequences = num_unique_nongapped_seqs <= 2
+        if too_few_unique_sequences:
+            return True
+
+        num_unique_gapped_seqs = get_number_of_unique_gapped_sequences(alignment)
+
+        # this is an assert as if it happens, something very wrong with the two previous functions is happening
+        assert num_unique_nongapped_seqs <= num_unique_gapped_seqs
+
+        alignment_has_ambiguity = num_unique_nongapped_seqs < num_unique_gapped_seqs
+        if alignment_has_ambiguity:
+            # TODO: fix alignment by deduplicating nongapped seqs and realigning them
+            # TODO: the annoying thing is that this deduplicated nongapped alignment will differ from the input alignment
+            # TODO: but I think it can be an ok solution
+            return True
+
+        return False
+
+    def _infer_if_this_node_should_have_no_child(self) -> bool:
+        if self.force_no_child:
+            return True
+
+        single_match_interval = (len(self.all_intervals) == 1) and (
+                self.all_intervals[0] in self.match_intervals
+        )
+        if single_match_interval:
+            return True
+
+        max_nesting_level_reached = self.nesting_level == self.prg_builder.max_nesting
+        if max_nesting_level_reached:
+            return True
+
+        small_variant_site = self.alignment.get_alignment_length() < self.prg_builder.min_match_length
+        if small_variant_site:
+            return True
+
+        # TODO: this could be computationally optimised (time performance) by receiving this bool variable by
+        # TODO: parameter in the constructor, and not recomputing it here. But I think we lose code readability,
+        # TODO: maintenability and introduce an annoying dependence... But something to think about if we want to push
+        # TODO: performance
+        alignment_has_issues = self._alignment_has_issues(self.alignment)
+        if alignment_has_issues:
+            return True
+
+        return False
+
+    def _infer_if_should_not_cluster(self, interval: Interval, alignment: MSA):
+        is_a_match_interval = interval in self.match_intervals
+        if is_a_match_interval:
+            return True
+
+        alignment_has_issues = self._alignment_has_issues(self.alignment)
+        if alignment_has_issues:
+            return True
+
+        clustering_result = kmeans_cluster_seqs(alignment, self.prg_builder.min_match_length)
+        if clustering_result.no_clustering:
+            return True
+
+        return False
+
+    def _get_children(self) -> List["RecursiveTreeNode"]:
+        node_has_no_child = self._infer_if_this_node_should_have_no_child()
+        if node_has_no_child:
+            return list()
+
+        children = []
+        for interval in self.all_intervals:
+            sub_alignment = self.alignment[:, interval.start : interval.stop + 1]
+            sub_alignment_will_not_be_reclustered = self._infer_if_should_not_cluster(interval, sub_alignment)
+            if sub_alignment_will_not_be_reclustered:
+                subclass = SingleClusterNode
+            else:
+                subclass = MultiClusterNode
+            child = subclass(
+                nesting_level=self.nesting_level + 1,
+                alignment=sub_alignment,
+                parent=self,
+                prg_builder=self.prg_builder,
+                force_no_child=sub_alignment_will_not_be_reclustered
+            )
+            children.append(child)
+
+        return children
+
+    def _get_prg(self, prg_as_list: List[str], delim_char: str = " "):
+        sequences_can_be_obtained_directly_from_clustering = False
+        if not self.is_root():
+            clustering_result = kmeans_cluster_seqs(self.alignment, self.prg_builder.min_match_length)
+            sequences_can_be_obtained_directly_from_clustering = clustering_result.have_precomputed_sequences
+
+        sequences_of_each_interval = []
+        if sequences_can_be_obtained_directly_from_clustering:
+            sequences_of_each_interval.append(clustering_result.sequences)
+        else:
+            for interval in self.all_intervals:
+                sub_alignment = self.alignment[:, interval.start:interval.stop + 1]
+                seqs = SequenceExpander.get_expanded_sequences_from_MSA(sub_alignment)
+                sequences_of_each_interval.append(seqs)
+
+        for sequences_of_this_interval in sequences_of_each_interval:
+            single_seq = len(sequences_of_this_interval) == 1
+            if single_seq:
+                start_index = len(prg_as_list)
+                prg_as_list.extend(sequences_of_this_interval[0])
+                end_index = len(prg_as_list)
+                self.prg_builder.update_PRG_index(start_index, end_index, node=self)
+            else:
+                # Add the variant seqs to the prg
+                site_num = self.prg_builder.get_next_site_num()
+                prg_as_list.extend(f"{delim_char}{site_num}{delim_char}")
+                for seq_index, seq in enumerate(sequences_of_this_interval):
+                    site_num_for_this_seq = (
+                        (site_num + 1) if (seq_index < len(sequences_of_this_interval) - 1) else site_num
+                    )
+                    start_index = len(prg_as_list)
+                    prg_as_list.extend(seq)
+                    end_index = len(prg_as_list)
+                    self.prg_builder.update_PRG_index(
+                        start_index, end_index, node=self
+                    )
+                    prg_as_list.extend(
+                        f"{delim_char}{site_num_for_this_seq}{delim_char}"
+                    )
+
+    ##################################################################################
+    # traversal methods
+    def preorder_traversal_to_build_prg(self, prg_as_list: List["str"], delim_char: str = " "):
+        if self.is_leaf():
+            self._get_prg(prg_as_list, delim_char)
+        else:
+            for child in self.children:
+                child.preorder_traversal_to_build_prg(prg_as_list, delim_char)
+    ##################################################################################
+
+    ##################################################################################
+    # update methods
+    def add_data_to_batch_update(self, update_data: UpdateData):
+        update_data_PRG_interval = update_data.ml_path_node_key
+        update_data_PRG_interval_is_indexed = update_data_PRG_interval in self.indexed_PRG_intervals
+        if not update_data_PRG_interval_is_indexed:
+            raise UpdateError(f"PRG interval {update_data_PRG_interval} not found in indexed "
+                              f"PRG intervals for node: {self.indexed_PRG_intervals}")
+
+        seq_to_add_as_list = []
+        for PRG_interval in sorted(self.indexed_PRG_intervals):
+            ML_sequence_should_be_replaced = PRG_interval == update_data_PRG_interval
+            if ML_sequence_should_be_replaced:
+                seq_to_add_as_list.append(update_data.new_node_sequence)
+            else:
+                try:
+                    ml_path_node = update_data.ml_path.get_node_given_interval_in_PRG_space(PRG_interval)
+                    seq_to_add_as_list.append(ml_path_node.sequence)
+                except MLPathError:
+                    pass
+
+        seq_to_add = "".join(seq_to_add_as_list)
+
+        there_has_been_padding = seq_to_add != update_data.new_node_sequence
+        if there_has_been_padding:
+            logger.trace(f"Sequence {update_data.new_node_sequence} padded to {seq_to_add} on "
+                         f"add_data_to_batch_update() for {self.prg_builder.locus_name}")
+
+        self.new_sequences.add(seq_to_add)
+
+    def add_indexed_PRG_interval(self, interval: Tuple[int, int]):
+        self.indexed_PRG_intervals.add(interval)
+
+    def batch_update(self):
+        no_update_to_be_done = len(self.new_sequences) == 0
+        if no_update_to_be_done:
+            return
+        self._update_leaf()
+
+    def _update_leaf(self):
+        logger.trace(f"Updating MSA for {self.prg_builder.locus_name}")
+        logger.trace(f"Node: {str(self)}")
+        logger.trace(f"Sequences added to update: {self.new_sequences}")
+
+        an_aligner_was_given = self.prg_builder.aligner is not None
+        assert an_aligner_was_given, "Cannot make updates without a Multiple Sequence Aligner."
+
+        self.alignment = self.prg_builder.aligner.get_updated_alignment(
+            current_alignment=self.alignment,
+            new_sequences=self.new_sequences
+        )
+
+        # regenerate recursion tree
+        self._init_pre_recursion_attributes()
+        self._children = self._get_children()
+    ##################################################################################
+
+    def __repr__(self):
+        return "SingleClusterNode:\n" + RecursiveTreeNode.__repr__(self) + \
+               f"Consensus: {self.consensus}\n" \
+               f"Match intervals: {self.match_intervals}\n" \
+               f"Non-match intervals: {self.non_match_intervals}\n"

--- a/make_prg/recursion_tree.py
+++ b/make_prg/recursion_tree.py
@@ -1,5 +1,5 @@
 """
-This module contains the classes to explicitly represent the make_prg process recursion tree
+This module contains classes to explicitly represent the make_prg process recursion tree
 """
 
 from typing import List, Set, Optional, Tuple

--- a/make_prg/recursion_tree.py
+++ b/make_prg/recursion_tree.py
@@ -276,7 +276,7 @@ class NodeFactory:
         # if parent is multi interval, children should not be
         skip_building_multi_interval_node = isinstance(parent_node, MultiIntervalNode)
         if not skip_building_multi_interval_node:
-            all_intervals, match_intervals = NodeFactory._get_all_and_match_intervals(alignment, min_match_length)
+            all_intervals, match_intervals = NodeFactory._get_vertical_partition(alignment, min_match_length)
 
             has_a_single_interval = NodeFactory._infer_if_has_single_interval(all_intervals=all_intervals, match_intervals=match_intervals,
                                                                 nesting_level=nesting_level,
@@ -361,7 +361,7 @@ class NodeFactory:
         return False
 
     @staticmethod
-    def _get_all_and_match_intervals(alignment: MSA, min_match_length: int) -> Tuple[Intervals, Intervals]:
+    def _get_vertical_partition(alignment: MSA, min_match_length: int) -> Tuple[Intervals, Intervals]:
         consensus = get_consensus_from_MSA(alignment)
         interval_partitioner = IntervalPartitioner(consensus, min_match_length, alignment)
         (

--- a/make_prg/recursion_tree.py
+++ b/make_prg/recursion_tree.py
@@ -22,14 +22,14 @@ SubMSAs = List[MSA]
 
 
 class RecursiveTreeNode(ABC):
+    """
+    Abstract base class for the nodes of the recursion tree, abstracting its common attributes and methods
+    """
     def __init__(self, nesting_level: int, alignment: MSA,
                  parent: Optional["RecursiveTreeNode"], prg_builder: "PrgBuilder",
                  children_subalignments: SubMSAs):
         """
-        Builds a new recursive tree node.
-        Notes:
-            1. To build a node you need to know in advance how it is going to cluster (horizontally or vertically).
-                This is given in the children_subalignments param. NodeFactory.build() takes care of this (see below).
+        Builds a new tree node, and its children, recursively
         """
         self.nesting_level: int = nesting_level
         self.alignment: MSA = remove_columns_full_of_gaps_from_MSA(alignment)
@@ -84,7 +84,7 @@ class RecursiveTreeNode(ABC):
 
 class MultiIntervalNode(RecursiveTreeNode):
     """
-    Represent nodes that are clustered vertically, i.e. in intervals
+    Represents a vertical partition of an MSA
     """
     def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
                  prg_builder: "PrgBuilder", interval_subalignments: SubMSAs):
@@ -101,7 +101,7 @@ class MultiIntervalNode(RecursiveTreeNode):
 
 class MultiClusterNode(RecursiveTreeNode):
     """
-    Represent nodes that are clustered horizontally, i.e. in sequence clusters
+    Represents a horizontal partition of an MSA, i.e. sequence clusters
     """
     def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],
                  prg_builder: "PrgBuilder", cluster_subalignments: SubMSAs):
@@ -132,7 +132,7 @@ class UpdateError(Exception):
 
 class LeafNode(RecursiveTreeNode):
     """
-    Represent nodes that are never clustered in either direction.
+    Represents MSAs that are never partitioned.
     These nodes are the only ones that can get updated and indexed.
     """
     def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],

--- a/make_prg/recursion_tree.py
+++ b/make_prg/recursion_tree.py
@@ -14,6 +14,70 @@ from make_prg.update.denovo_variants import UpdateData
 from make_prg.update.MLPath import MLPathError
 from abc import ABC, abstractmethod
 
+SubMSAs: List[MSA]
+
+
+class PrgNode(ABC):
+    @abstractmethod
+    def get_prg(self):
+        pass
+
+class MultiIntervalNode(PrgNode):
+    def __init__(self, vertical_clusters: SubMSAs):
+        for interval in intervals:
+            self.children.append(NodeFactory.build(sub_MSA, skip_intervals = True))
+
+    def get_prg(self):
+        site = ""
+        for child in self.children:
+            site += child.get_prg()
+        return site
+
+class MultiClusterNode(PrgNode):
+    def __init__(self, horizontal_clusters: SubMSAs):
+        for hori_cluster in horizontal_clusters:
+            self.children.append(NodeFactory.build(sub_MSA, skip_clustering = True))
+
+    def get_prg():
+        site = open_site()
+        for child in self.children:
+            # add each allele
+            site += child.get_prg()
+            site += allele_delim
+        return site
+
+class Leaf(PrgNode):
+    def __init__(self, MSA: MSA):
+        if only_one_seq(MSA):
+            self.prg = MSA[0]
+        else:
+            # make a set of alleles
+            self.prg = make_allele_set(MSA)
+    def get_prg():
+        return self.prg
+
+
+class NodeFactory:
+    @staticmethod
+    def build(MSA, skip_intervals: bool = False, skip_clustering: bool = False):
+        # Or: pass in `parent`, that is a `PrgNode`, and determine whether or not to
+        # skip interval/clustering based on parent class type. Also allows forwarding
+        # attributes like `nesting_level` to constructors
+        assert not all([skip_intervals, skip_clustering])
+        if not skip_intervals and has_intervals(MSA):
+            vertical_clusters: SubMSAs = get_intervals()
+            return MultiIntervalNode(vertical_clusters)
+        # has_clusters should check the clustering_result to see if there was a
+        # clustering
+        elif not skip_clustering and has_clusters(MSA):
+            horizontal_clusters: SubMSAs = get_clusters()
+            return MultiClusterNode(clusters)
+        else:
+            return Leaf()
+
+# In main():
+root = NodeFactory(MSA) # Creates the whole tree
+prg = root.get_prg() # Pre_order traversal producing the prg string
 
 class RecursiveTreeNode(ABC):
     def __init__(self, nesting_level: int, alignment: MSA, parent: Optional["RecursiveTreeNode"],

--- a/make_prg/update/MLPath.py
+++ b/make_prg/update/MLPath.py
@@ -1,3 +1,7 @@
+"""
+This module contains classes to represent and operate on maximum likelihood paths described in denovo_paths.txt files
+"""
+
 from typing import Optional, List, Tuple, Dict
 from intervaltree.intervaltree import IntervalTree
 

--- a/make_prg/update/MLPath.py
+++ b/make_prg/update/MLPath.py
@@ -1,0 +1,116 @@
+from typing import Optional, List, Tuple, Dict
+from intervaltree.intervaltree import IntervalTree
+
+
+class MLPathError(Exception):
+    pass
+
+
+class EmptyMLPathSequence(Exception):
+    pass
+
+
+class MLPathNode:
+    def __init__(self, key: Tuple[int, int], sequence: str):
+        self.key: Tuple[int, int] = key
+        self._set_sequence(sequence)
+
+        # these are set by class MLPath during indexing
+        self.start_index_in_linear_path: Optional[int] = None
+        self.end_index_in_linear_path: Optional[int] = None
+
+        self._check_is_a_valid_node()
+
+    def _set_sequence(self, sequence: str):
+        empty_ML_path_sequence = len(sequence) == 0
+        if empty_ML_path_sequence:
+            raise EmptyMLPathSequence(f"Found a ML path node ({self.key}) with empty sequence")
+        self.sequence: str = sequence
+
+    def _check_is_a_valid_node(self):
+        interval_size = self.key[1] - self.key[0]
+        sequence_size = len(self.sequence)
+        valid_node = interval_size == sequence_size
+        if not valid_node:
+            raise MLPathError(f"{self} is not a valid node")
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (self.key, self.sequence) == (other.key, other.sequence)
+        else:
+            return False
+
+    def __hash__(self):
+        return hash((self.key, self.sequence))
+
+    def __str__(self):
+        return f"PRG key = {self.key}; " \
+               f"ML seq interval = [{self.start_index_in_linear_path}:{self.end_index_in_linear_path}]; " \
+               f"Seq = {self.sequence}"
+
+    def __repr__(self):
+        return f"MLPathNode(key={self.key}, sequence=\"{self.sequence}\")"
+
+
+class MLPath:
+    def __init__(self, ml_path_nodes: List[MLPathNode]):
+        if len(ml_path_nodes) == 0:
+            raise MLPathError("ML paths cannot be empty")
+        self._ml_path_nodes: List[MLPathNode] = ml_path_nodes
+        self._ml_path_index_in_linear_path_space: IntervalTree = IntervalTree()
+        self._ml_path_index_in_PRG_space: Dict[Tuple[int, int], MLPathNode] = {}  # dict because this is exact index
+        self._index()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
+    def _index(self):
+        start_index_in_linear_path = 0
+        for ml_path_node_index, ml_path_node in enumerate(self._ml_path_nodes):
+            end_index_in_linear_path = start_index_in_linear_path + len(ml_path_node.sequence)
+            self._ml_path_index_in_linear_path_space.addi(
+                start_index_in_linear_path,
+                end_index_in_linear_path,
+                data=ml_path_node,
+            )
+            ml_path_node.start_index_in_linear_path = start_index_in_linear_path
+            ml_path_node.end_index_in_linear_path = end_index_in_linear_path
+            start_index_in_linear_path = end_index_in_linear_path
+
+            self._ml_path_index_in_PRG_space[ml_path_node.key] = ml_path_node
+
+    def get_last_insertion_pos(self) -> int:
+        """
+        This position is not indexed, but can be where we insert a sequence after the last base of the last node
+        """
+        return self._ml_path_nodes[-1].end_index_in_linear_path
+
+    def get_last_node(self) -> MLPathNode:
+        return self._ml_path_nodes[-1]
+
+    def get_node_given_position_in_linear_path_space(self, position: int) -> MLPathNode:
+        nodes = self._ml_path_index_in_linear_path_space[position]
+
+        two_or_more_nodes_overlap_this_position = len(nodes) >= 2
+        assert not two_or_more_nodes_overlap_this_position, f"2+ nodes overlap at position {position}, " \
+                                                            f"this ML path ({self}) probably has an indexing bug."
+        no_nodes_overlap_this_position = len(nodes) == 0
+        if no_nodes_overlap_this_position:
+            raise MLPathError(f"No nodes overlap this ML path ({self}) at position {position}, "
+                              f"is the denovo_paths.txt given as input correct?")
+
+        # only one node overlap this position
+        node = list(nodes)[0].data
+        return node
+
+    def get_node_given_interval_in_PRG_space(self, interval: Tuple[int, int]) -> MLPathNode:
+        leaf_interval_not_indexed = interval not in self._ml_path_index_in_PRG_space
+        if leaf_interval_not_indexed:
+            raise MLPathError(f"PRG space interval ({interval}) not indexed in this node ({self})")
+        return self._ml_path_index_in_PRG_space[interval]
+
+    def __repr__(self):
+        return f"MLPath({self._ml_path_nodes})"

--- a/make_prg/update/MLPath.py
+++ b/make_prg/update/MLPath.py
@@ -15,6 +15,10 @@ class EmptyMLPathSequence(Exception):
 
 
 class MLPathNode:
+    """
+    Represents a maximum likelihood path node described in denovo_paths.txt files, e.g.:
+    (2 [117, 118) G)
+    """
     def __init__(self, key: Tuple[int, int], sequence: str):
         self.key: Tuple[int, int] = key
         self._set_sequence(sequence)
@@ -57,6 +61,19 @@ class MLPathNode:
 
 
 class MLPath:
+    """
+    Represents a maximum likelihood path described in denovo_paths.txt files, e.g.:
+    9 nodes
+    (0 [0, 110) ATGCAGATACGTGAACAGGGCCGCAAAATTCAGTGCATCCGCACCGTGTACGACAAGGCCATTGGCCGGGGTCGGCAGACGGTCATTGCCACACTGGCCCGCTATACGAC)
+    (2 [117, 118) G)
+    (3 [121, 171) GAAATGCCCACGACCGGGCTGGATGAGCTGACAGAGGCCGAACGCGAGAC)
+    (5 [178, 179) G)
+    (6 [182, 301) CTGGCCGAATGGCTGGCCAAGCGCCGGGAAGCCTCGCAGAAGTCGCAGGAGGCCTACACGGCCATGTCTGCGGATCGGTGGCTGGTCACGCTGGCCAAGGCCATCAGGGAAGGGCAGGA)
+    (8 [312, 316) ACTG)
+    (9 [319, 360) CGCCCCGAACAGGCGGCCGCGATCTGGCACGGCATGGGGGA)
+    (11 [369, 370) G)
+    (12 [374, 491) GTCGGCAAGGCCTTGCGCAAGGCTGGTCACGCGAAGCCCAAGGCGGTCAGAAAGGGCAAGCCGGTCGATCCGGCTGATCCCAAGGATCAAGGGGAGGGGGCACCAAAGGGGAAATGA)
+    """
     def __init__(self, ml_path_nodes: List[MLPathNode]):
         if len(ml_path_nodes) == 0:
             raise MLPathError("ML paths cannot be empty")

--- a/make_prg/update/denovo_variants.py
+++ b/make_prg/update/denovo_variants.py
@@ -1,0 +1,389 @@
+from typing import List, Deque, TextIO, Dict, Tuple, Optional
+from collections import defaultdict, deque
+import re
+from loguru import logger
+from collections import Counter
+from make_prg.utils.seq_utils import align, GAP
+from make_prg.update.MLPath import MLPathNode, MLPath, EmptyMLPathSequence, MLPathError
+from pathlib import Path
+from make_prg.utils.misc import remove_duplicated_consecutive_elems_from_list
+from dataclasses import dataclass
+
+
+class DenovoError(Exception):
+    pass
+
+
+class DenovoVariant:
+    def __init__(self, start_index_in_linear_path: int, ref: str, alt: str,
+                 ml_path_nodes_it_goes_through: Optional[List[MLPathNode]] = None):
+        DenovoVariant._param_checking(start_index_in_linear_path, ref, alt)
+        self.start_index_in_linear_path: int = start_index_in_linear_path
+        self.end_index_in_linear_path: int = start_index_in_linear_path + len(ref)
+        self.ref: str = ref
+        self.alt: str = alt
+        self.set_ml_path_nodes_it_goes_through(ml_path_nodes_it_goes_through)
+
+    @staticmethod
+    def _param_checking(start_index_in_linear_path: int, ref: str, alt: str):
+        DenovoVariant._check_sequence_is_composed_of_ACGT_only(ref)
+        DenovoVariant._check_sequence_is_composed_of_ACGT_only(alt)
+        not_a_variant = ref == alt
+        if not_a_variant:
+            raise DenovoError(f"Found a variant where ref ({ref}) equals alt ({alt}), this is not a variant")
+
+        negative_index_for_variant_pos = start_index_in_linear_path < 0
+        if negative_index_for_variant_pos:
+            raise DenovoError(f"Found a negative index for variant pos ({start_index_in_linear_path})")
+
+    @staticmethod
+    def _check_sequence_is_composed_of_ACGT_only(seq: str):
+        sequence_is_composed_of_ACGT_only = all([base in "ACGT" for base in seq])
+        if not sequence_is_composed_of_ACGT_only:
+            raise DenovoError(f"Found a non-ACGT seq ({seq}) in a denovo variant")
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
+    def set_ml_path_nodes_it_goes_through(self, ml_path_nodes_it_goes_through: Optional[List[MLPathNode]]):
+        """
+        self.ml_path_nodes_it_goes_through: a list of MLPathNode, where the i-th MLPathNode is the node the i-th base
+        of the variant goes through
+        """
+        if ml_path_nodes_it_goes_through is not None:
+            if self.is_strict_insertion_event():
+                ml_path_contains_only_the_insertion_point = len(ml_path_nodes_it_goes_through) == 1
+                valid_parameters = ml_path_contains_only_the_insertion_point
+            else:
+                each_base_is_covered_by_one_node = len(self.ref) == len(ml_path_nodes_it_goes_through)
+                valid_parameters = each_base_is_covered_by_one_node
+            assert valid_parameters, f"Invalid parameters for DenovoVariant.set_ml_path_nodes_it_goes_through().\n" \
+                                     f"Debug info:\n" \
+                                     f"DenovoVariant: {self}\n" \
+                                     f"ml_path_nodes_it_goes_through: {ml_path_nodes_it_goes_through}"
+
+        self.ml_path_nodes_it_goes_through: Optional[List[MLPathNode]] = ml_path_nodes_it_goes_through
+
+    def get_mutated_sequence(self) -> str:
+        """
+        We apply this variant to the single MLPathNode in self.ml_path_it_goes_through.
+        self.ml_path_it_goes_through needs to have a single node compatible with this variant
+        """
+        ml_path_nodes_it_goes_through_has_a_single_distinct_node = self.ml_path_nodes_it_goes_through is not None and \
+                                                                   len(set(self.ml_path_nodes_it_goes_through)) == 1
+        assert ml_path_nodes_it_goes_through_has_a_single_distinct_node, \
+            f"Cannot apply variant {self} as it does not go through a single distinct node\n" \
+            f"ML path nodes the variant goes through: {self.ml_path_nodes_it_goes_through}"
+
+        node = self.ml_path_nodes_it_goes_through[0]
+        node_is_compatible_with_this_variant = \
+            node.start_index_in_linear_path <= self.start_index_in_linear_path and \
+            self.end_index_in_linear_path <= node.end_index_in_linear_path
+        assert node_is_compatible_with_this_variant,  f"Node {node} is not compatible with variant {self}"
+
+        start_index_inside_node_sequence = (
+            self.start_index_in_linear_path - node.start_index_in_linear_path
+        )
+        end_index_inside_node_sequence = start_index_inside_node_sequence + len(
+            self.ref
+        )
+        ref_wrt_indexes = node.sequence[
+            start_index_inside_node_sequence:end_index_inside_node_sequence
+        ]
+        ref_is_consistent = self.ref == ref_wrt_indexes
+        assert ref_is_consistent, f"Ref is not consistent for {self}. Node = {node}. ref_wrt_indexes = {ref_wrt_indexes}"
+
+        mutated_sequence = (
+            node.sequence[:start_index_inside_node_sequence]
+            + self.alt
+            + node.sequence[end_index_inside_node_sequence:]
+        )
+        return mutated_sequence
+
+    def _split_variant_at_boundary_alignment(self, ref_alignment: Deque[str], alt_alignment: Deque[str]) -> List["DenovoVariant"]:
+        split_variants = []
+        current_index_in_linear_path = self.start_index_in_linear_path
+        ml_path_node_to_count = Counter(self.ml_path_nodes_it_goes_through)
+        deduplicated_ml_path_nodes_it_goes_through = remove_duplicated_consecutive_elems_from_list(self.ml_path_nodes_it_goes_through)
+        for ml_path_node_index, ml_path_node in enumerate(deduplicated_ml_path_nodes_it_goes_through):
+            sub_ref = []
+            sub_alt = []
+            nb_of_bases_to_consume = ml_path_node_to_count[ml_path_node]
+            current_start_in_linear_path = current_index_in_linear_path
+
+            while nb_of_bases_to_consume > 0:
+                ref_base = ref_alignment.popleft()
+                if ref_base != GAP:
+                    sub_ref.append(ref_base)
+                    current_index_in_linear_path += 1
+                    nb_of_bases_to_consume -= 1
+
+                alt_base = alt_alignment.popleft()
+                if alt_base != GAP:
+                    sub_alt.append(alt_base)
+
+            is_last_node = ml_path_node_index == len(deduplicated_ml_path_nodes_it_goes_through) - 1
+            there_are_remaining_alt_bases = is_last_node and nb_of_bases_to_consume==0 and len(alt_alignment)>0
+            if there_are_remaining_alt_bases:
+                sub_alt.extend([alt_base for alt_base in alt_alignment if alt_base != GAP])
+
+            sub_ref_seq = "".join(sub_ref)
+            sub_alt_seq = "".join(sub_alt)
+            sub_ref_and_alt_are_different = sub_ref_seq != sub_alt_seq
+            if sub_ref_and_alt_are_different:
+                split_variant = DenovoVariant(
+                    current_start_in_linear_path, sub_ref_seq, sub_alt_seq
+                )
+                ml_path_nodes_the_split_variant_goes_through = [ml_path_node] * len(sub_ref_seq)
+                split_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_the_split_variant_goes_through)
+                split_variants.append(split_variant)
+
+        return split_variants
+
+    def split_variant(self) -> List["DenovoVariant"]:
+        """
+        Split this variant into a list of sub-variants WRT how it is distributed along self.ml_path_nodes_it_goes_through
+        @return: List of sub-variants that goes through only a single node
+        """
+        ml_path_nodes_it_goes_through_is_valid = self.ml_path_nodes_it_goes_through is not None
+        assert ml_path_nodes_it_goes_through_is_valid, f"Error on DenovoVariant.split_variant(): " \
+                                                       f"self.ml_path_nodes_it_goes_through is None"
+
+        nb_of_distinct_ml_path_nodes = len(set(self.ml_path_nodes_it_goes_through))
+        variant_goes_through_only_one_leaf = nb_of_distinct_ml_path_nodes == 1
+        if variant_goes_through_only_one_leaf:
+            split_variants = [self]
+            return split_variants
+
+        # here, variant goes through several leaves
+        alignment = align(self.ref, self.alt)
+        ref_alignment = deque(alignment[0])
+        alt_alignment = deque(alignment[1])
+        split_variants = self._split_variant_at_boundary_alignment(ref_alignment, alt_alignment)
+        return split_variants
+
+    def is_strict_insertion_event(self) -> bool:
+        """
+        A strict insertion event is when the ref is empty and the alt has some bases
+        """
+        return len(self.ref) == 0 and len(self.alt) > 0
+
+    def __str__(self):
+        return f"[{self.start_index_in_linear_path}:{self.end_index_in_linear_path}]:'{self.ref}'->'{self.alt}'"
+
+    def __repr__(self):
+        return f"DenovoVariant(start_index_in_linear_path={self.start_index_in_linear_path}, " \
+               f"ref=\"{self.ref}\", " \
+               f"alt=\"{self.alt}\")"
+
+
+@dataclass
+class UpdateData:
+    ml_path_node_key: Tuple[int, int]
+    ml_path: MLPath
+    new_node_sequence: str
+
+
+@dataclass
+class DenovoLocusInfo:
+    sample: str
+    locus: str
+    ml_path: MLPath
+    variants: List[DenovoVariant]
+
+    def _get_ml_path_nodes_spanning_variant(self, variant: DenovoVariant) -> List[MLPathNode]:
+        """
+        Given a variant, return a list of MLPathNodes spanning the variant.
+        For each base of the ref of variant, we have one MLPathNode, so if we have a ref == "ACGT", the list will
+        contain 4 MLPathNodes.
+        """
+        if variant.is_strict_insertion_event():
+            # interval/ref is empty, search for the start index
+            try:
+                ml_path_node = self.ml_path.get_node_given_position_in_linear_path_space(variant.start_index_in_linear_path)
+            except MLPathError as ml_path_error:
+                # this might happen when the insertion is after the last base of the last node
+                is_in_the_last_insertion_position = variant.start_index_in_linear_path == self.ml_path.get_last_insertion_pos()
+                if is_in_the_last_insertion_position:
+                    ml_path_node = self.ml_path.get_last_node()
+                else:
+                    # this is indeed an error
+                    raise ml_path_error
+            ml_path_nodes = [ml_path_node]
+        else:
+            # we have a real interval / ref is not empty
+            ml_path_nodes = []
+            for position_in_linear_path in range(
+                    variant.start_index_in_linear_path, variant.end_index_in_linear_path
+            ):
+                ml_path_node = self.ml_path.get_node_given_position_in_linear_path_space(position_in_linear_path)
+                ml_path_nodes.append(ml_path_node)
+
+        return ml_path_nodes
+
+    def get_update_data(self) -> List[UpdateData]:
+        """
+        Get a list of updates to be done to MLPathNodes to update the PRG
+        """
+        update_data_list = []
+        for variant in self.variants:
+            ml_path_nodes = self._get_ml_path_nodes_spanning_variant(variant)
+            variant.set_ml_path_nodes_it_goes_through(ml_path_nodes)
+            split_variants = variant.split_variant()
+
+            for split_variant in split_variants:
+                update_data = UpdateData(
+                    ml_path_node_key=split_variant.ml_path_nodes_it_goes_through[0].key,
+                    ml_path=self.ml_path,
+                    new_node_sequence=split_variant.get_mutated_sequence()
+                )
+                update_data_list.append(update_data)
+
+        return update_data_list
+
+
+class DenovoVariantsDB:
+    @staticmethod
+    def _read_nb_of_samples(filehandler: TextIO) -> int:
+        line = filehandler.readline().strip()
+        nb_of_samples = int(line.split()[0])
+        return nb_of_samples
+
+    @staticmethod
+    def _read_sample(filehandler: TextIO) -> str:
+        line = filehandler.readline().strip()
+        sample = line.split()[1]
+        logger.trace(f"Read sample: {sample}")
+        return sample
+
+    @staticmethod
+    def _read_nb_of_loci_in_sample(filehandler: TextIO) -> int:
+        line = filehandler.readline().strip()
+        nb_of_loci_in_sample = int(line.split()[0])
+        return nb_of_loci_in_sample
+
+    @staticmethod
+    def _read_locus(filehandler: TextIO) -> str:
+        locus = filehandler.readline().strip()
+        logger.trace(f"Read locus: {locus}")
+        return locus
+
+    @staticmethod
+    def _read_nb_of_nodes_in_ml_path(filehandler: TextIO) -> int:
+        line = filehandler.readline().strip()
+        nb_of_nodes_in_ml_path = int(line.split()[0])
+        return nb_of_nodes_in_ml_path
+
+    @classmethod
+    def _read_MLPathNode(cls, filehandler: TextIO) -> MLPathNode:
+        line = filehandler.readline().strip()
+        try:
+            matches = cls.ml_path_regex.search(line)
+            start_index = int(matches.group(1))
+            end_index = int(matches.group(2))
+            sequence = matches.group(3)
+        except Exception as exc:
+            assert False, f"Failed matching ML path regex to line: {line}\n" \
+                          f"Exception: {str(exc)}"
+
+        ml_path_node = MLPathNode(key=(start_index, end_index), sequence=sequence)
+        return ml_path_node
+
+    @classmethod
+    def _read_ml_path(cls, filehandler: TextIO) -> MLPath:
+        nb_of_nodes_in_ml_path = cls._read_nb_of_nodes_in_ml_path(filehandler)
+        ml_path = []
+        for _ in range(nb_of_nodes_in_ml_path):
+            try:
+                ml_path_node = cls._read_MLPathNode(filehandler)
+                ml_path.append(ml_path_node)
+            except EmptyMLPathSequence:
+                # if the ML path node has empty sequence, it has empty interval, so we just ignore it,
+                # as it is not amenable to updates
+                pass
+
+        logger.trace(f"Read ML path: {ml_path}")
+        return MLPath(ml_path)
+
+    @staticmethod
+    def _read_nb_of_variants(filehandler: TextIO) -> int:
+        line = filehandler.readline().strip()
+        nb_of_variants = int(line.split()[0])
+        return nb_of_variants
+
+    @staticmethod
+    def _read_DenovoVariant(filehandler: TextIO) -> DenovoVariant:
+        line = filehandler.readline().strip("\n")
+        line_split = line.split("\t")
+
+        start_index_in_linear_path = int(line_split[0]) - 1
+        ref = line_split[1]
+        alt = line_split[2]
+        denovo_variant = DenovoVariant(
+                start_index_in_linear_path=start_index_in_linear_path,
+                ref=ref,
+                alt=alt,
+        )
+
+        logger.trace(f"Read variant: {denovo_variant}")
+        return denovo_variant
+
+    @classmethod
+    def _read_variants(cls, filehandler) -> List[DenovoVariant]:
+        nb_of_variants = cls._read_nb_of_variants(filehandler)
+        variants = []
+        for _ in range(nb_of_variants):
+            denovo_variant = cls._read_DenovoVariant(filehandler)
+            variants.append(denovo_variant)
+        return variants
+
+    def _get_locus_name_to_denovo_loci_core(self, filehandler: TextIO) -> Dict[str, List[DenovoLocusInfo]]:
+        locus_name_to_denovo_loci = defaultdict(list)
+        try:
+            nb_of_samples = self._read_nb_of_samples(filehandler)
+        except IndexError:
+            logger.warning(
+                f"File containing denovo paths ({self.filepath}) is empty, is it the correct file?"
+            )
+            return locus_name_to_denovo_loci
+
+        for sample_index in range(nb_of_samples):
+            sample = self._read_sample(filehandler)
+            nb_of_loci_in_sample = self._read_nb_of_loci_in_sample(filehandler)
+            for locus_index in range(nb_of_loci_in_sample):
+                locus = self._read_locus(filehandler)
+                ml_path = self._read_ml_path(filehandler)
+                variants = self._read_variants(filehandler)
+                denovo_locus = DenovoLocusInfo(sample, locus, ml_path, variants)
+                locus_name_to_denovo_loci[locus].append(denovo_locus)
+
+        return locus_name_to_denovo_loci
+
+    def _get_locus_name_to_denovo_loci(self) -> Dict[str, List[DenovoLocusInfo]]:
+        with open(self.filepath) as filehandler:
+            return self._get_locus_name_to_denovo_loci_core(filehandler)
+
+    @staticmethod
+    def _get_locus_name_to_update_data(
+            locus_name_to_denovo_loci: Dict[str, List[DenovoLocusInfo]])\
+            -> Dict[str, List[UpdateData]]:
+        locus_name_to_update_data = defaultdict(list)
+        for locus_name, denovo_loci in locus_name_to_denovo_loci.items():
+            for denovo_locus in denovo_loci:
+                update_data = denovo_locus.get_update_data()
+                locus_name_to_update_data[locus_name].extend(update_data)
+        return locus_name_to_update_data
+
+    def __init__(self, filepath: str):
+        self.filepath: Path = Path(filepath)
+        locus_name_to_denovo_loci = self._get_locus_name_to_denovo_loci()
+        self.locus_name_to_update_data = self._get_locus_name_to_update_data(
+            locus_name_to_denovo_loci
+        )
+
+    # Example:
+    # (0 [0, 110) ATGCAGATACGTGAACAGGGCCGCAAAATTCAGTGCATCCGCACCGTGTACGACAAGGCCATTGGCCGGGGTCGGCAGACGGTCATTGCCACACTGGCCCGCTATACGAC)
+    ml_path_regex = re.compile(r"\(\d+ \[(\d+), (\d+)\) ([ACGT]*)\)")

--- a/make_prg/update/denovo_variants.py
+++ b/make_prg/update/denovo_variants.py
@@ -1,3 +1,7 @@
+"""
+This module contains classes used to parse and represent denovo variants info contained in a denovo_paths.txt file
+"""
+
 from typing import List, Deque, TextIO, Dict, Tuple, Optional
 from collections import defaultdict, deque
 import re

--- a/make_prg/update/denovo_variants.py
+++ b/make_prg/update/denovo_variants.py
@@ -19,6 +19,9 @@ class DenovoError(Exception):
 
 
 class DenovoVariant:
+    """
+    Represents a denovo variant in a denovo_paths.txt file, e.g.: "44	C	T"
+    """
     def __init__(self, start_index_in_linear_path: int, ref: str, alt: str,
                  ml_path_nodes_it_goes_through: Optional[List[MLPathNode]] = None):
         DenovoVariant._param_checking(start_index_in_linear_path, ref, alt)
@@ -186,6 +189,10 @@ class DenovoVariant:
 
 @dataclass
 class UpdateData:
+    """
+    Represents a trivial minimal class to hold update data when multiprocessing
+    """
+
     ml_path_node_key: Tuple[int, int]
     ml_path: MLPath
     new_node_sequence: str
@@ -193,6 +200,23 @@ class UpdateData:
 
 @dataclass
 class DenovoLocusInfo:
+    """
+    Represents a locus  in a denovo_paths.txt file, e.g.:
+    GC00010897
+    9 nodes
+    (0 [0, 110) ATGCAGATACGTGAACAGGGCCGCAAAATTCAGTGCATCCGCACCGTGTACGACAAGGCCATTGGCCGGGGTCGGCAGACGGTCATTGCCACACTGGCCCGCTATACGAC)
+    (2 [117, 118) G)
+    (3 [121, 171) GAAATGCCCACGACCGGGCTGGATGAGCTGACAGAGGCCGAACGCGAGAC)
+    (5 [178, 179) G)
+    (6 [182, 301) CTGGCCGAATGGCTGGCCAAGCGCCGGGAAGCCTCGCAGAAGTCGCAGGAGGCCTACACGGCCATGTCTGCGGATCGGTGGCTGGTCACGCTGGCCAAGGCCATCAGGGAAGGGCAGGA)
+    (8 [312, 316) ACTG)
+    (9 [319, 360) CGCCCCGAACAGGCGGCCGCGATCTGGCACGGCATGGGGGA)
+    (11 [369, 370) G)
+    (12 [374, 491) GTCGGCAAGGCCTTGCGCAAGGCTGGTCACGCGAAGCCCAAGGCGGTCAGAAAGGGCAAGCCGGTCGATCCGGCTGATCCCAAGGATCAAGGGGAGGGGGCACCAAAGGGGAAATGA)
+    2 denovo variants for this locus
+    44	C	T
+    422	A	T
+    """
     sample: str
     locus: str
     ml_path: MLPath
@@ -250,6 +274,10 @@ class DenovoLocusInfo:
 
 
 class DenovoVariantsDB:
+    """
+    Represents the whole denovo_paths.txt file. Most important member is the attribute self.locus_name_to_update_data,
+    where users can get the update data given a locus.
+    """
     @staticmethod
     def _read_nb_of_samples(filehandler: TextIO) -> int:
         line = filehandler.readline().strip()

--- a/make_prg/utils/recursive_tree_drawer.py
+++ b/make_prg/utils/recursive_tree_drawer.py
@@ -1,4 +1,4 @@
-from make_prg.recursion_tree import RecursiveTreeNode, SingleClusterNode
+from make_prg.recursion_tree import RecursiveTreeNode, MultiIntervalNode, MultiClusterNode, LeafNode
 import networkx as nx
 import matplotlib.pyplot as plt
 from pathlib import Path
@@ -23,21 +23,30 @@ class RecursiveTreeDrawer:
     @staticmethod
     def _visit(node: RecursiveTreeNode, graph: nx.DiGraph):
         node_attributes = {}
-        node_is_SingleClusterNode = isinstance(node, SingleClusterNode)
 
         if node.is_leaf():
-            assert node_is_SingleClusterNode, "Error, a leaf is not a SingleClusterNode"
             prg_as_list = []
-            node._get_prg(prg_as_list)
+            node.preorder_traversal_to_build_prg(prg_as_list, do_indexing=False)
             node_attributes["label"] = "".join(prg_as_list)
         else:
             node_attributes["label"] = str(node.id)
 
-        node_attributes["color"] = "blue" if node_is_SingleClusterNode else "red"
+        node_attributes["color"] = RecursiveTreeDrawer._get_node_colour(node)
         graph.add_node(node, **node_attributes)
 
         if node.parent is not None:
             graph.add_edge(node.parent, node)
+
+    @staticmethod
+    def _get_node_colour(node: RecursiveTreeNode) -> str:
+        if isinstance(node, MultiClusterNode):
+            return "red"
+        elif isinstance(node, MultiIntervalNode):
+            return "blue"
+        elif isinstance(node, LeafNode):
+            return "green"
+        else:
+            assert False, f"Unknown node class when drawing: {node.__class__}"
 
     def output_graph(self, filename: Path):
         plt.figure(figsize=(20, 10))

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from setuptools import setup, find_packages
 
+with open("./README.md") as fhandle:
+    readme = fhandle.read()
+
 setup(
     name="make_prg",
     version="0.2.0",
+    description="Build genome graphs (PRGs) from multiple sequence alignments",
+    long_description=readme,
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     url="https://github.com/rmcolq/make_prg",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    url="https://github.com/rmcolq/make_prg",
+    url="https://github.com/iqbal-lab-org/make_prg",
     license="MIT",
     entry_points={"console_scripts": ["make_prg = make_prg.__main__:main"]},
     test_suite="nose.collector",

--- a/tests/test_prg_builder.py
+++ b/tests/test_prg_builder.py
@@ -1,0 +1,252 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock, mock_open
+from make_prg.prg_builder import PrgBuilder, LeafNotFoundException, PrgBuilderZipDatabase
+from pathlib import Path
+from tests.test_helpers import sample_prg, are_zip_files_equal
+import filecmp
+from zipfile import ZipFile
+
+workdir = Path("tests/data/prg_builder/write_prg")
+
+
+class TestPrgBuilder(TestCase):
+    # Note: can't use setUp() as patches are not applied to it
+    def setup_prg_builder(self) -> None:
+        self.locus = "locus"
+        self.aligner = Mock()
+        self.max_nesting = 5
+        self.min_match_length = 7
+        self.prg_builder = PrgBuilder(self.locus, Path("msa_file"), "fasta",
+                                      self.max_nesting, self.min_match_length, self.aligner)
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___constructor(self, SingleClusterNode_mock, load_alignment_file_mock):
+        self.setup_prg_builder()
+        self.assertEqual(self.locus, self.prg_builder.locus_name)
+        self.assertEqual(self.max_nesting, self.prg_builder.max_nesting)
+        self.assertEqual(self.min_match_length, self.prg_builder.min_match_length)
+        self.assertEqual(self.aligner, self.prg_builder.aligner)
+        self.assertEqual(0, self.prg_builder.next_node_id)
+        self.assertEqual(5, self.prg_builder.site_num)
+        self.assertEqual({}, self.prg_builder.prg_index)
+        self.assertEqual("SingleClusterNode", self.prg_builder.root)
+        load_alignment_file_mock.assert_called_once_with("msa_file", "fasta")
+        SingleClusterNode_mock.assert_called_once_with(
+            nesting_level=0,
+            alignment="MSA",
+            parent=None,
+            prg_builder=self.prg_builder
+        )
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode")
+    def test___build_prg(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+
+        def preorder_traversal_to_build_prg_mock_fun(prg_as_list):
+            prg_as_list.extend(["a", "b", "c"])
+        preorder_traversal_to_build_prg_mock = Mock(side_effect=preorder_traversal_to_build_prg_mock_fun)
+        self.prg_builder.root.preorder_traversal_to_build_prg = preorder_traversal_to_build_prg_mock
+
+        expected = "abc"
+        actual = self.prg_builder.build_prg()
+
+        self.assertEqual(expected, actual)
+        preorder_traversal_to_build_prg_mock.assert_called_once()
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___get_next_site_num(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+        self.assertEqual(5, self.prg_builder.get_next_site_num())
+        self.assertEqual(7, self.prg_builder.get_next_site_num())
+        self.assertEqual(9, self.prg_builder.get_next_site_num())
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___get_next_node_id(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+        self.assertEqual(0, self.prg_builder.get_next_node_id())
+        self.assertEqual(1, self.prg_builder.get_next_node_id())
+        self.assertEqual(2, self.prg_builder.get_next_node_id())
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___update_prg_index___single_update(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+        add_indexed_PRG_interval_mock = Mock()
+        node_mock_1 = Mock(add_indexed_PRG_interval=add_indexed_PRG_interval_mock)
+        self.prg_builder.update_PRG_index(2, 5, node_mock_1)
+
+        expected = {(2, 5): node_mock_1}
+        actual = self.prg_builder.prg_index
+
+        self.assertEqual(expected, actual)
+        add_indexed_PRG_interval_mock.assert_called_once_with((2, 5))
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___update_prg_index___multiple_updates(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+        node_mock_1 = Mock()
+        node_mock_2 = Mock()
+        node_mock_3 = Mock()
+        node_mock_4 = Mock()
+        self.prg_builder.update_PRG_index(2, 5, node_mock_1)
+        self.prg_builder.update_PRG_index(0, 10, node_mock_2)
+        self.prg_builder.update_PRG_index(100, 200, node_mock_3)
+        self.prg_builder.update_PRG_index(2, 5, node_mock_4)
+
+        expected = {
+            (0, 10): node_mock_2,
+            (2, 5): node_mock_4,
+            (100, 200): node_mock_3,
+        }
+        actual = self.prg_builder.prg_index
+
+        self.assertEqual(expected, actual)
+
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___get_node_given_interval(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+        node_mock_1 = Mock()
+        node_mock_2 = Mock()
+        node_mock_3 = Mock()
+        self.prg_builder.update_PRG_index(2, 5, node_mock_1)
+        self.prg_builder.update_PRG_index(3, 8, node_mock_2)
+        self.prg_builder.update_PRG_index(5, 9, node_mock_3)
+
+        self.assertEqual(node_mock_1, self.prg_builder.get_node_given_interval((2, 5)))
+        self.assertEqual(node_mock_2, self.prg_builder.get_node_given_interval((3, 8)))
+        self.assertEqual(node_mock_3, self.prg_builder.get_node_given_interval((5, 9)))
+        for i in range(11):
+            for j in range(11):
+                interval = (i, j)
+                if interval != (2, 5) and interval != (3, 8) and interval != (5, 9):
+                    with self.assertRaises(LeafNotFoundException):
+                        self.prg_builder.get_node_given_interval(interval)
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("pickle.dump")
+    def test___serialize(self, dump_mock, open_mock, *uninteresting_mocks):
+        self.setup_prg_builder()
+        self.prg_builder.serialize("filepath")
+        open_mock.assert_called_once_with("filepath", 'wb')
+
+        # did not manage to assert equality of arg [1] (which is the open_mock handler)
+        # so asserting equality of arg [0]
+        dump_mock.assert_called_once()
+        self.assertEqual(self.prg_builder, dump_mock.call_args[0][0])
+
+    @patch("pickle.loads")
+    def test___array_of_bytes(self, loads_mock, *uninteresting_mocks):
+        array_of_bytes = b"test"
+        PrgBuilder.deserialize_from_bytes(array_of_bytes)
+        loads_mock.assert_called_once_with(array_of_bytes)
+
+    def test___write_prg_as_text(self):
+        PrgBuilder.write_prg_as_text(f"{workdir}/sample", sample_prg)
+        self.assertTrue(filecmp.cmp(workdir / "sample.prg.fa", workdir / "sample.truth.prg.fa"))
+
+    def test___write_prg_as_binary(self):
+        PrgBuilder.write_prg_as_binary(f"{workdir}/sample", sample_prg)
+        self.assertTrue(filecmp.cmp(workdir / "sample.bin", workdir / "sample.truth.bin"))
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    @patch("os.makedirs")
+    def test___output_debug_graphs(self, makedirs_mock, *uninteresting_mocks):
+        self.setup_prg_builder()
+        debug_graphs_dir = Path("debug_graphs")
+
+        output_graph_mock = Mock(name="output_graph_mock")
+        with patch("make_prg.prg_builder.RecursiveTreeDrawer") as RecursiveTreeDrawer_mock:
+            RecursiveTreeDrawer_mock.return_value = Mock(output_graph = output_graph_mock)
+            self.prg_builder.output_debug_graphs(debug_graphs_dir)
+
+            makedirs_mock.assert_called_once_with(debug_graphs_dir, exist_ok=True)
+            RecursiveTreeDrawer_mock.assert_called_once_with(self.prg_builder.root)
+            output_graph_mock.assert_called_with(debug_graphs_dir / "locus.recursion_tree.png")
+
+    @patch("make_prg.prg_builder.load_alignment_file", return_value="MSA")
+    @patch("make_prg.prg_builder.SingleClusterNode", return_value="SingleClusterNode")
+    def test___get_state___aligner_is_not_pickled(self, *uninteresting_mocks):
+        self.setup_prg_builder()
+
+        expected = self.prg_builder.__dict__
+        expected['aligner'] = None
+        actual = self.prg_builder.__getstate__()
+
+        self.assertEqual(expected, actual)
+
+
+class TestPrgBuilderZipDatabase(TestCase):
+    def setUp(self) -> None:
+        self.zip_filepath = Path("tests/data/utils/io_utils/zip_set_of_files/files.truth.zip")
+        self.prg_builder_zip_db = PrgBuilderZipDatabase(self.zip_filepath)
+
+    def tearDown(self) -> None:
+        self.prg_builder_zip_db.close()
+
+    def test___constructor___not_a_zip_file___raises_AssertionError(self):
+        with self.assertRaises(AssertionError):
+            PrgBuilderZipDatabase(Path("file.txt"))
+
+    def test___constructor(self):
+        self.assertTrue(are_zip_files_equal(self.zip_filepath, self.prg_builder_zip_db._zip_filepath))
+
+    @patch("make_prg.prg_builder.zip_set_of_files")
+    def test___save(self, zip_set_of_files_mock):
+        locus_to_prg_builder_pickle_path_mock = Mock()
+
+        self.prg_builder_zip_db.save(locus_to_prg_builder_pickle_path_mock)
+
+        zip_set_of_files_mock.assert_called_once_with(self.prg_builder_zip_db._zip_filepath,
+                                                      locus_to_prg_builder_pickle_path_mock)
+
+    def test___load(self):
+        self.assertIsNone(self.prg_builder_zip_db._zip_file)
+        self.prg_builder_zip_db.load()
+        self.assertIsNotNone(self.prg_builder_zip_db._zip_file)
+
+    @patch.object(ZipFile, ZipFile.close.__name__)
+    def test___close___zip_file_not_loaded___close_not_called(self, zipfile_close_mock):
+        self.prg_builder_zip_db.close()
+        zipfile_close_mock.assert_not_called()
+
+    @patch.object(ZipFile, ZipFile.close.__name__)
+    def test___close___zip_file_loaded___close_called(self, zipfile_close_mock):
+        self.prg_builder_zip_db.load()
+        self.prg_builder_zip_db.close()
+        zipfile_close_mock.assert_called_once_with()
+
+    def test___get_number_of_loci(self):
+        self.prg_builder_zip_db.load()
+
+        expected = 3
+        actual = self.prg_builder_zip_db.get_number_of_loci()
+
+        self.assertEqual(expected, actual)
+
+    def test___get_loci_names(self):
+        self.prg_builder_zip_db.load()
+
+        expected = ["f1", "file_2", "file3"]
+        actual = self.prg_builder_zip_db.get_loci_names()
+
+        self.assertEqual(expected, actual)
+
+    @patch.object(ZipFile, ZipFile.read.__name__, return_value="read_mock")
+    @patch.object(PrgBuilder, PrgBuilder.deserialize_from_bytes.__name__)
+    def test___get_PrgBuilder(self, deserialize_from_bytes_mock, zipfile_read_mock):
+        self.prg_builder_zip_db.load()
+        self.prg_builder_zip_db.get_PrgBuilder("locus")
+
+        zipfile_read_mock.assert_called_once_with("locus")
+        deserialize_from_bytes_mock.assert_called_once_with("read_mock")
+

--- a/tests/test_recursion_tree.py
+++ b/tests/test_recursion_tree.py
@@ -1,0 +1,1023 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock, PropertyMock
+from tests.test_helpers import make_alignment, equal_msas, first_dict_contained_in_second
+from make_prg.recursion_tree import MultiClusterNode, SingleClusterNode, UpdateError, RecursiveTreeNode
+from make_prg.prg_builder import PrgBuilder
+from make_prg.from_msa import MSA
+from pathlib import Path
+from make_prg.from_msa.interval_partition import IntervalType, Interval
+from make_prg.utils.seq_utils import SequenceExpander
+from make_prg.update.denovo_variants import UpdateData, MLPathError
+from make_prg.from_msa.cluster_sequences import ClusteringResult
+
+
+@patch.object(PrgBuilder, PrgBuilder.get_next_node_id.__name__, return_value=0)
+@patch.object(SingleClusterNode, SingleClusterNode.__init__.__name__, return_value=None)
+@patch("make_prg.prg_builder.load_alignment_file")
+@patch.object(RecursiveTreeNode, RecursiveTreeNode.log_that_node_was_created.__name__)
+class TestMultiClusterNode(TestCase):
+    def partial_setup(self) -> None:
+        self.alignment = make_alignment(
+            ["AAAT", "C--C", "AATT", "GNGG"], ["s1", "s2", "s3", "s4"]
+        )
+        self.prg_builder = PrgBuilder("locus", Path("msa"), "fasta", 5, 7)
+
+    # Note: can't apply patches to setUp(), so creating this method that is called in every test
+    def setup(self) -> None:
+        self.partial_setup()
+        self.multi_cluster_node = MultiClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+    @patch.object(MultiClusterNode, MultiClusterNode._get_children.__name__, return_value=["child_1", "child_2"])
+    @patch("make_prg.recursion_tree.remove_columns_full_of_gaps_from_MSA", return_value="remove_columns_full_of_gaps_from_MSA_mock")
+    def test___constructor(self, *uninteresting_mocks):
+        self.setup()
+        parent_mock = Mock()
+        node = MultiClusterNode(1, self.alignment, parent_mock, self.prg_builder, False)
+
+        self.assertEqual(1, node.nesting_level)
+        self.assertTrue("remove_columns_full_of_gaps_from_MSA_mock", node.alignment)
+        self.assertEqual(parent_mock, node.parent)
+        self.assertEqual(self.prg_builder, node.prg_builder)
+        self.assertFalse(node.force_no_child)
+        self.assertEqual(0, node.id)
+        self.assertEqual(["child_1", "child_2"], node.children)
+
+    @patch.object(MultiClusterNode, MultiClusterNode._get_children.__name__, return_value=[])
+    def test___constructor___no_children___raises_AssertionError(self, *uninteresting_mocks):
+        alignment = make_alignment(["A"])
+        prg_builder = PrgBuilder("locus", Path("msa"), "fasta", 5, 7)
+        with self.assertRaises(AssertionError):
+            MultiClusterNode(1, alignment, None, prg_builder, False)
+
+
+
+
+    class Preorder_traversal_to_build_prg_Mock:
+        def __init__(self, child_id):
+            self.child_id = child_id
+        def preorder_traversal_to_build_prg(self, prg_as_list, delim_char):
+            prg_as_list.append(f"child_{self.child_id}")
+
+    @patch.object(PrgBuilder, PrgBuilder.get_next_site_num.__name__, return_value=32)
+    def test___preorder_traversal_to_build_prg___single_child(self, *mocks):
+        self.setup()
+        node = MultiClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+        # get the original method
+        preorder_traversal_to_build_prg = MultiClusterNode.preorder_traversal_to_build_prg
+
+        # now patch the children
+        children = [TestMultiClusterNode.Preorder_traversal_to_build_prg_Mock(1)]
+        with patch.object(MultiClusterNode, "children", new_callable=PropertyMock, return_value=children):
+            # call the original method with the recursive calls now patched
+            prg_as_list = []
+            preorder_traversal_to_build_prg(node, prg_as_list, delim_char="*")
+
+            expected_prg = "*32*child_1*32*"
+            actual_prg = "".join(prg_as_list)
+
+            self.assertEqual(expected_prg, actual_prg)
+
+    @patch.object(PrgBuilder, PrgBuilder.get_next_site_num.__name__, return_value=32)
+    def test___preorder_traversal_to_build_prg___multiple_children(self, *mocks):
+        self.partial_setup()
+        node = MultiClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+        # get the original method
+        preorder_traversal_to_build_prg = MultiClusterNode.preorder_traversal_to_build_prg
+
+        # now patch the children
+        children = [TestMultiClusterNode.Preorder_traversal_to_build_prg_Mock(1),
+                    TestMultiClusterNode.Preorder_traversal_to_build_prg_Mock(2),
+                    TestMultiClusterNode.Preorder_traversal_to_build_prg_Mock(3)]
+        with patch.object(MultiClusterNode, "children", new_callable=PropertyMock, return_value=children):
+            # call the original method with the recursive calls now patched
+            prg_as_list = []
+            preorder_traversal_to_build_prg(node, prg_as_list, delim_char="*")
+
+            expected_prg = "*32*child_1*33*child_2*33*child_3*32*"
+            actual_prg = "".join(prg_as_list)
+
+            self.assertEqual(expected_prg, actual_prg)
+
+
+
+    @patch("make_prg.recursion_tree.kmeans_cluster_seqs", return_value=ClusteringResult(
+        [["s5", "s0", "s1", "s6"], ["s3"], ["s2", "s4"]]))
+    def test___get_subalignments_by_clustering(self, *uninteresting_mocks):
+        alignment = make_alignment(
+            ["AAAT", "C--C", "AATT", "GNGG", "CCCC", "TTTT", "AAAA"], ["s0", "s1", "s2", "s3", "s4", "s5", "s6"]
+        )
+        prg_builder = PrgBuilder("locus", Path("msa"), "fasta", 5, 7)
+        node = MultiClusterNode(1, alignment, None, prg_builder, False)
+
+        expected = [
+            make_alignment(
+                ["AAAT", "C--C", "TTTT", "AAAA"], ["s0", "s1", "s5", "s6"]),
+            make_alignment(
+                ["GNGG"], ["s3"]),
+            make_alignment(
+                ["AATT", "CCCC"],
+                ["s2", "s4"]),
+        ]
+        actual = node._get_subalignments_by_clustering()
+
+        self.assertEqual(3, len(actual))
+        for i in range(3):
+            self.assertTrue(equal_msas(expected[i], actual[i]))
+
+    @patch.object(MultiClusterNode, MultiClusterNode._get_children.__name__, return_value=["child_1", "child_2"])
+    def test___get_sub_alignment_by_list_id___GivenOrderedIds_SubalignmentInSequenceOrder(self, *uninteresting_mocks):
+        self.setup()
+        expected = MSA([self.alignment[0], self.alignment[2]])
+        actual = self.multi_cluster_node._get_sub_alignment_by_list_id(["s1", "s3"])
+        self.assertTrue(equal_msas(expected, actual))
+
+    @patch.object(MultiClusterNode, MultiClusterNode._get_children.__name__, return_value=["child_1", "child_2"])
+    def test___get_sub_alignment_by_list_id___GivenUnorderedIds_SubalignmentStillInSequenceOrder(self, *uninteresting_mocks):
+        """
+        Sequences given rearranged are still output in input order
+        """
+        self.setup()
+        expected = MSA([self.alignment[0], self.alignment[2]])
+        actual = self.multi_cluster_node._get_sub_alignment_by_list_id(["s3", "s1"])
+        self.assertTrue(equal_msas(expected, actual))
+
+    @patch("make_prg.recursion_tree.SingleClusterNode")
+    @patch.object(MultiClusterNode, MultiClusterNode._get_subalignments_by_clustering.__name__)
+    def test___get_children___single_cluster(self, get_subalignments_by_clustering_mock, SingleClusterNode_mock,
+                                             *mocks):
+        single_alignment = make_alignment(["AAAT", "C--C", "AATT"])
+        subalignments = [single_alignment]
+        get_subalignments_by_clustering_mock.return_value = subalignments
+        self.setup()
+
+        expected = [SingleClusterNode_mock.return_value]
+        actual = self.multi_cluster_node.children
+
+        self.assertEqual(expected, actual)
+        SingleClusterNode_mock.assert_called_once_with(
+            nesting_level=1,
+            alignment=single_alignment,
+            parent=self.multi_cluster_node,
+            prg_builder=self.prg_builder,
+            force_no_child=True
+        )
+
+    get_children___multiple_clusters___SingleClusterNode___side_effect = [Mock(), Mock(), Mock()]
+    @patch("make_prg.recursion_tree.SingleClusterNode", side_effect=get_children___multiple_clusters___SingleClusterNode___side_effect)
+    @patch.object(MultiClusterNode, MultiClusterNode._get_subalignments_by_clustering.__name__)
+    def test___get_children___multiple_clusters(self, get_subalignments_by_clustering_mock, SingleClusterNode_mock,
+                                             *mocks):
+        alignment_1 = make_alignment(["AAAT", "C--C", "AATT"])
+        alignment_2 = make_alignment(["GGGG"])
+        alignment_3 = make_alignment(["CCCC", "TTTT"])
+
+        subalignments = [alignment_1, alignment_2, alignment_3]
+        get_subalignments_by_clustering_mock.return_value = subalignments
+        self.setup()
+
+        expected = self.get_children___multiple_clusters___SingleClusterNode___side_effect
+        actual = self.multi_cluster_node.children
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(3, SingleClusterNode_mock.call_count)
+        SingleClusterNode_mock.assert_any_call(
+            nesting_level=1,
+            alignment=alignment_1,
+            parent=self.multi_cluster_node,
+            prg_builder=self.prg_builder,
+            force_no_child=False
+        )
+        SingleClusterNode_mock.assert_any_call(
+            nesting_level=1,
+            alignment=alignment_2,
+            parent=self.multi_cluster_node,
+            prg_builder=self.prg_builder,
+            force_no_child=False
+        )
+        SingleClusterNode_mock.assert_any_call(
+            nesting_level=1,
+            alignment=alignment_3,
+            parent=self.multi_cluster_node,
+            prg_builder=self.prg_builder,
+            force_no_child=False
+        )
+
+    def test___repr_and_str(self, *uninteresting_mocks):
+        self.setup()
+        self.multi_cluster_node._children = [Mock(id=100), Mock(id=200)]
+        expected = """MultiClusterNode:
+Id = 0
+Nesting level = 1
+Force no child = False
+Parent = None
+Children = [Id = 100, Id = 200]
+Alignment:
+>s1
+AAAT
+>s2
+C--C
+>s3
+AATT
+>s4
+GNGG
+"""
+        actual = repr(self.multi_cluster_node)
+        self.assertEqual(expected, actual)
+
+        actual = str(self.multi_cluster_node)
+        self.assertEqual(expected, actual)
+
+
+@patch.object(PrgBuilder, PrgBuilder.get_next_node_id.__name__, return_value=0)
+@patch("make_prg.prg_builder.load_alignment_file")
+@patch.object(RecursiveTreeNode, RecursiveTreeNode.log_that_node_was_created.__name__)
+class TestSingleClusterNode(TestCase):
+    def subsetup(self):
+        self.alignment = make_alignment(
+            ["AAAT", "C--C", "AATT", "GNGG"], ["s1", "s2", "s3", "s4"]
+        )
+        with patch.object(SingleClusterNode, PrgBuilder.__init__.__name__, return_value=None):
+            self.prg_builder = PrgBuilder("locus", Path("msa"), "fasta", 5, 7)
+
+    # Note: can't apply patches to setUp(), so creating this method that is called in every test
+    def setup(self) -> None:
+        self.subsetup()
+        self.single_cluster_node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+        self.single_cluster_node.clustering_result = None
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__, return_value=["child_1", "child_2"])
+    @patch("make_prg.recursion_tree.remove_columns_full_of_gaps_from_MSA",
+           return_value="remove_columns_full_of_gaps_from_MSA_mock")
+    @patch("make_prg.recursion_tree.kmeans_cluster_seqs", return_value="clustered_sequences")
+    @patch("make_prg.recursion_tree.get_consensus_from_MSA", return_value="consensus_from_MSA")
+    @patch("make_prg.recursion_tree.IntervalPartitioner")
+    def test___constructor(self, IntervalPartitioner_mock, get_consensus_from_MSA_mock, *uninteresting_mocks):
+        alignment = make_alignment(
+            ["AAAT", "C--C", "AATT", "GNGG"], ["s1", "s2", "s3", "s4"]
+        )
+        with patch.object(SingleClusterNode, PrgBuilder.__init__.__name__, return_value=None):
+            prg_builder = PrgBuilder("locus", Path("msa"), "fasta", 5, 7)
+        parent_mock = Mock()
+        class GetIntervalsMock:
+            def get_intervals(self):
+                return "match_intervals", "non_match_intervals", "all_intervals"
+        get_intervals_mock = GetIntervalsMock()
+        IntervalPartitioner_mock.return_value = get_intervals_mock
+
+        node = SingleClusterNode(1, alignment, parent_mock, prg_builder, False)
+
+        self.assertEqual(1, node.nesting_level)
+        self.assertTrue("remove_columns_full_of_gaps_from_MSA_mock", node.alignment)
+        self.assertEqual(parent_mock, node.parent)
+        self.assertEqual(prg_builder, node.prg_builder)
+        self.assertFalse(node.force_no_child)
+        self.assertEqual(0, node.id)
+        self.assertEqual(["child_1", "child_2"], node.children)
+        self.assertEqual("consensus_from_MSA", node.consensus)
+        self.assertEqual(len("consensus_from_MSA"), node.length)
+        self.assertEqual("match_intervals", node.match_intervals)
+        self.assertEqual("non_match_intervals", node.non_match_intervals)
+        self.assertEqual("all_intervals", node.all_intervals)
+        get_consensus_from_MSA_mock.assert_called_once_with("remove_columns_full_of_gaps_from_MSA_mock")
+        IntervalPartitioner_mock.assert_called_once_with("consensus_from_MSA", 7, "remove_columns_full_of_gaps_from_MSA_mock")
+        self.assertEqual(set(), node.new_sequences)
+        self.assertEqual(set(), node.indexed_PRG_intervals)
+
+    @patch("make_prg.recursion_tree.get_consensus_from_MSA", return_value="consensus_from_MSA")
+    @patch("make_prg.recursion_tree.IntervalPartitioner")
+    def test___init_pre_recursion_attributes(self, IntervalPartitioner_mock, get_consensus_from_MSA_mock, *uninteresting_mocks):
+        class GetIntervalsMock:
+            def get_intervals(self):
+                return "match_intervals", "non_match_intervals", "all_intervals"
+        get_intervals_mock = GetIntervalsMock()
+        IntervalPartitioner_mock.return_value = get_intervals_mock
+
+        single_cluster_mock = Mock()
+        single_cluster_mock.prg_builder.min_match_length = 7
+        single_cluster_mock.alignment = Mock()
+        SingleClusterNode._init_pre_recursion_attributes(single_cluster_mock)
+
+        self.assertEqual("consensus_from_MSA", single_cluster_mock.consensus)
+        self.assertEqual(len("consensus_from_MSA"), single_cluster_mock.length)
+        self.assertEqual("match_intervals", single_cluster_mock.match_intervals)
+        self.assertEqual("non_match_intervals", single_cluster_mock.non_match_intervals)
+        self.assertEqual("all_intervals", single_cluster_mock.all_intervals)
+        self.assertEqual(set(), single_cluster_mock.new_sequences)
+        self.assertEqual(set(), single_cluster_mock.indexed_PRG_intervals)
+        get_consensus_from_MSA_mock.assert_called_once_with(single_cluster_mock.alignment)
+        IntervalPartitioner_mock.assert_called_once_with("consensus_from_MSA", 7, single_cluster_mock.alignment)
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__, return_value=[])
+    def test___is_leaf___is_indeed_leaf(self, *uninteresting_mocks):
+        self.setup()
+        node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+        self.assertTrue(node.is_leaf())
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__, return_value=[Mock()])
+    def test___is_leaf___is_not_leaf(self, *uninteresting_mocks):
+        self.setup()
+        node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+        self.assertFalse(node.is_leaf())
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__)
+    def test___is_root___is_indeed_root(self, *uninteresting_mocks):
+        self.setup()
+        node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+        self.assertTrue(node.is_root())
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__)
+    def test___is_root___is_not_root(self, *uninteresting_mocks):
+        self.setup()
+        node = SingleClusterNode(1, self.alignment, Mock(), self.prg_builder, False)
+
+        self.assertFalse(node.is_root())
+
+    @patch("make_prg.recursion_tree.get_number_of_unique_ungapped_sequences", return_value=1)
+    def test___alignment_has_issues___num_unique_nongapped_seqs_1(self,
+                 get_number_of_unique_ungapped_sequences_mock, *uninteresting_mocks):
+        self.setup()
+        self.assertTrue(self.single_cluster_node._alignment_has_issues(self.single_cluster_node.alignment))
+        get_number_of_unique_ungapped_sequences_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    @patch("make_prg.recursion_tree.get_number_of_unique_ungapped_sequences", return_value=2)
+    def test___alignment_has_issues___num_unique_nongapped_seqs_2(self,
+                 get_number_of_unique_ungapped_sequences_mock, *uninteresting_mocks):
+        self.setup()
+        self.assertTrue(self.single_cluster_node._alignment_has_issues(self.single_cluster_node.alignment))
+        get_number_of_unique_ungapped_sequences_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    @patch("make_prg.recursion_tree.get_number_of_unique_ungapped_sequences", return_value=3)
+    @patch("make_prg.recursion_tree.get_number_of_unique_gapped_sequences", return_value=4)
+    def test___alignment_has_issues___alignment_has_ambiguity___ungapped_smaller_gapped(self,
+         get_number_of_unique_gapped_sequences_mock, get_number_of_unique_ungapped_sequences_mock, *uninteresting_mocks):
+        self.setup()
+        self.assertTrue(self.single_cluster_node._alignment_has_issues(self.single_cluster_node.alignment))
+        get_number_of_unique_gapped_sequences_mock.assert_called_once_with(self.single_cluster_node.alignment)
+        get_number_of_unique_ungapped_sequences_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    @patch("make_prg.recursion_tree.get_number_of_unique_ungapped_sequences", return_value=4)
+    @patch("make_prg.recursion_tree.get_number_of_unique_gapped_sequences", return_value=4)
+    def test___alignment_has_issues___alignment_has_ambiguity___ungapped_equals_gapped___no_issues(self,
+        get_number_of_unique_gapped_sequences_mock, get_number_of_unique_ungapped_sequences_mock, *uninteresting_mocks):
+        self.setup()
+        self.assertFalse(self.single_cluster_node._alignment_has_issues(self.single_cluster_node.alignment))
+        get_number_of_unique_gapped_sequences_mock.assert_called_once_with(self.single_cluster_node.alignment)
+        get_number_of_unique_ungapped_sequences_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    @patch("make_prg.recursion_tree.get_number_of_unique_ungapped_sequences", return_value=5)
+    @patch("make_prg.recursion_tree.get_number_of_unique_gapped_sequences", return_value=4)
+    def test___alignment_has_issues___alignment_has_ambiguity___ungapped_larger_gapped___raises_AssertionError(self,
+        *uninteresting_mocks):
+        self.setup()
+        with self.assertRaises(AssertionError):
+            self.single_cluster_node._alignment_has_issues(self.single_cluster_node.alignment)
+
+    def test___infer_if_this_node_should_have_no_child___force_no_child(self, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.force_no_child = True
+
+        self.assertTrue(self.single_cluster_node._infer_if_this_node_should_have_no_child())
+
+    def test___infer_if_this_node_should_have_no_child___single_match_interval(self, *uninteresting_mocks):
+        self.setup()
+        interval = Interval(IntervalType.Match, 3, 10)
+        self.single_cluster_node.force_no_child = False
+        self.single_cluster_node.all_intervals = [interval]
+        self.single_cluster_node.match_intervals = [interval]
+
+        self.assertTrue(self.single_cluster_node._infer_if_this_node_should_have_no_child())
+
+    def test___infer_if_this_node_should_have_no_child___max_nesting_level_reached(self, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.force_no_child = False
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 5),
+                                                  Interval(IntervalType.Match, 6, 10)]
+        self.single_cluster_node.nesting_level = 5
+
+        self.assertTrue(self.single_cluster_node._infer_if_this_node_should_have_no_child())
+
+    def test___infer_if_this_node_should_have_no_child___small_variant_site(self, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.force_no_child = False
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 5),
+                                                  Interval(IntervalType.Match, 6, 10)]
+        self.single_cluster_node.nesting_level = 1
+        self.single_cluster_node.prg_builder.min_match_length = 10
+
+        self.assertTrue(self.single_cluster_node._infer_if_this_node_should_have_no_child())
+
+    @patch.object(SingleClusterNode, SingleClusterNode._alignment_has_issues.__name__, return_value=True)
+    def test___infer_if_this_node_should_have_no_child___alignment_has_issues(self,
+            alignment_has_issues_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.force_no_child = False
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 5),
+                                                  Interval(IntervalType.Match, 6, 10)]
+        self.single_cluster_node.nesting_level = 1
+        self.single_cluster_node.prg_builder.min_match_length = 1
+
+        self.assertTrue(self.single_cluster_node._infer_if_this_node_should_have_no_child())
+        alignment_has_issues_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    @patch.object(SingleClusterNode, SingleClusterNode._alignment_has_issues.__name__, return_value=False)
+    def test___infer_if_this_node_should_have_no_child___no_issues___can_have_child(self,
+            alignment_has_issues_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.force_no_child = False
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 5),
+                                                  Interval(IntervalType.Match, 6, 10)]
+        self.single_cluster_node.nesting_level = 1
+        self.single_cluster_node.prg_builder.min_match_length = 1
+
+        self.assertFalse(self.single_cluster_node._infer_if_this_node_should_have_no_child())
+        alignment_has_issues_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    def test___infer_if_should_not_cluster___is_a_match_interval(self, *uninteresting_mocks):
+        self.setup()
+        interval = Interval(IntervalType.Match, 5, 10)
+        self.single_cluster_node.match_intervals = [Interval(IntervalType.Match, 0, 5),
+                                                    interval,
+                                                    Interval(IntervalType.Match, 20, 25)]
+
+        self.assertTrue(self.single_cluster_node._infer_if_should_not_cluster(interval, self.alignment))
+
+    @patch.object(SingleClusterNode, SingleClusterNode._alignment_has_issues.__name__, return_value=True)
+    def test___infer_if_should_not_cluster___alignment_has_issues(self,
+          alignment_has_issues_mock, *uninteresting_mocks):
+        self.setup()
+        interval = Interval(IntervalType.Match, 5, 10)
+        self.single_cluster_node.match_intervals = []
+
+        self.assertTrue(self.single_cluster_node._infer_if_should_not_cluster(interval, self.single_cluster_node.alignment))
+        alignment_has_issues_mock.assert_called_once_with(self.single_cluster_node.alignment)
+
+    @patch("make_prg.recursion_tree.kmeans_cluster_seqs", return_value=ClusteringResult(
+        [["s1", "s2", "s3", "s4"]]))
+    @patch.object(SingleClusterNode, SingleClusterNode._alignment_has_issues.__name__, return_value=False)
+    def test___infer_if_should_not_cluster___single_cluster(self,
+           alignment_has_issues_mock, kmeans_cluster_seqs_mock, *uninteresting_mocks):
+        self.setup()
+        interval = Interval(IntervalType.Match, 5, 10)
+        self.single_cluster_node.match_intervals = []
+
+        self.assertTrue(
+            self.single_cluster_node._infer_if_should_not_cluster(interval, self.single_cluster_node.alignment))
+        alignment_has_issues_mock.assert_called_once_with(self.single_cluster_node.alignment)
+        kmeans_cluster_seqs_mock.assert_called_once_with(self.single_cluster_node.alignment, self.prg_builder.min_match_length)
+
+    @patch("make_prg.recursion_tree.kmeans_cluster_seqs", return_value=ClusteringResult(
+        [["s1", "s2"], ["s3", "s4"]]))
+    @patch.object(SingleClusterNode, SingleClusterNode._alignment_has_issues.__name__, return_value=False)
+    def test___infer_if_should_not_cluster___two_clusters___no_issues_can_cluster(self,
+                                                            alignment_has_issues_mock, kmeans_cluster_seqs_mock,
+                                                            *uninteresting_mocks):
+        self.setup()
+        interval = Interval(IntervalType.Match, 5, 10)
+        self.single_cluster_node.match_intervals = []
+
+        self.assertFalse(
+            self.single_cluster_node._infer_if_should_not_cluster(interval, self.single_cluster_node.alignment))
+        alignment_has_issues_mock.assert_called_once_with(self.single_cluster_node.alignment)
+        kmeans_cluster_seqs_mock.assert_called_once_with(self.single_cluster_node.alignment,
+                                                         self.prg_builder.min_match_length)
+
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_this_node_should_have_no_child.__name__, return_value=True)
+    def test___get_children___node_should_have_no_child(self, *uninteresting_mocks):
+        self.subsetup()
+        node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+
+        expected = []
+        actual = node._get_children()
+
+        self.assertEqual(expected, actual)
+
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_this_node_should_have_no_child.__name__, return_value=False)
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_should_not_cluster.__name__, return_value=True)
+    def test___get_children___single_SingleClusterNode_child(self, *uninteresting_mocks):
+        self.subsetup()
+
+        # we mock get_children() here so that we don't trigger the recursion tree building
+        with patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__):
+            node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+        node.all_intervals = [Interval(IntervalType.Match, 0, 0)]
+
+        # now we mock SingleClusterNode so that we don't trigger the recursion tree building
+        child_mock = Mock()
+        with patch("make_prg.recursion_tree.SingleClusterNode", return_value=child_mock) as SingleClusterNode_mock:
+            expected = [child_mock]
+            actual = node._get_children()
+            self.assertEqual(expected, actual)
+            SingleClusterNode_mock.assert_called_once()
+
+            # assert_called_once_with() does not work because can't check if MSAs are equal
+            kwargs = SingleClusterNode_mock.call_args_list[0].kwargs
+            self.assertTrue(first_dict_contained_in_second({
+                    "nesting_level": node.nesting_level+1,
+                    "parent": node,
+                    "prg_builder": self.prg_builder,
+                    "force_no_child": True
+                }, kwargs))
+            self.assertTrue(equal_msas(self.alignment[:,0:1], kwargs["alignment"]))
+
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_this_node_should_have_no_child.__name__, return_value=False)
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_should_not_cluster.__name__, return_value=False)
+    def test___get_children___single_MultiClusterNode_child(self, *uninteresting_mocks):
+        self.subsetup()
+
+        # we mock get_children() here so that we don't trigger the recursion tree building
+        with patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__):
+            node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+        node.all_intervals = [Interval(IntervalType.Match, 0, 0)]
+
+        # now we mock MultiClusterNode so that we don't trigger the recursion tree building
+        child_mock = Mock()
+        with patch("make_prg.recursion_tree.MultiClusterNode", return_value=child_mock) as MultiClusterNode_mock:
+            expected = [child_mock]
+            actual = node._get_children()
+            self.assertEqual(expected, actual)
+            MultiClusterNode_mock.assert_called_once()
+
+            # assert_called_once_with() does not work because can't check if MSAs are equal
+            kwargs = MultiClusterNode_mock.call_args_list[0].kwargs
+            self.assertTrue(first_dict_contained_in_second({
+                    "nesting_level": node.nesting_level+1,
+                    "parent": node,
+                    "prg_builder": self.prg_builder,
+                    "force_no_child": False
+                }, kwargs))
+            self.assertTrue(equal_msas(self.alignment[:,0:1], kwargs["alignment"]))
+
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_this_node_should_have_no_child.__name__, return_value=False)
+    @patch.object(SingleClusterNode, SingleClusterNode._infer_if_should_not_cluster.__name__, side_effect=[True, False, True, False])
+    def test___get_children___multiple_children(self, *uninteresting_mocks):
+        self.subsetup()
+
+        # we mock get_children() here so that we don't trigger the recursion tree building
+        with patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__):
+            node = SingleClusterNode(1, self.alignment, None, self.prg_builder, False)
+        node.all_intervals = [Interval(IntervalType.Match, 0, 0),
+                              Interval(IntervalType.NonMatch, 1, 1),
+                              Interval(IntervalType.Match, 2, 2),
+                              Interval(IntervalType.NonMatch, 3, 3)]
+
+        # now we mock SingleClusterNode and MultiClusterNode so that we don't trigger the recursion tree building
+        single_cluster_node_mock_1 = Mock()
+        single_cluster_node_mock_2 = Mock()
+        multi_cluster_node_mock_1 = Mock()
+        multi_cluster_node_mock_2 = Mock()
+        with patch("make_prg.recursion_tree.MultiClusterNode", side_effect=[multi_cluster_node_mock_1, multi_cluster_node_mock_2]), \
+            patch("make_prg.recursion_tree.SingleClusterNode", side_effect=[single_cluster_node_mock_1, single_cluster_node_mock_2]):
+            expected = [single_cluster_node_mock_1, multi_cluster_node_mock_1, single_cluster_node_mock_2, multi_cluster_node_mock_2]
+            actual = node._get_children()
+            self.assertEqual(expected, actual)
+
+    @patch.object(SequenceExpander, SequenceExpander.get_expanded_sequences_from_MSA.__name__, return_value = ["ACGT"])
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___single_interval_and_single_seq(self, update_prg_index_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 0)]
+
+        expected_prg_as_list = list("ACGT")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        update_prg_index_mock.assert_called_once_with(0, 4, node=self.single_cluster_node)
+
+    @patch.object(SingleClusterNode, SingleClusterNode.is_root.__name__, return_value=False)
+    @patch("make_prg.recursion_tree.kmeans_cluster_seqs", return_value=Mock(have_precomputed_sequences=False))
+    @patch.object(SequenceExpander, SequenceExpander.get_expanded_sequences_from_MSA.__name__, return_value = ["ACGT"])
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___single_interval_and_single_seq___not_root_and_have_no_precomputed_sequences(self, update_prg_index_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 0)]
+
+        expected_prg_as_list = list("ACGT")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        update_prg_index_mock.assert_called_once_with(0, 4, node=self.single_cluster_node)
+
+    @patch.object(SingleClusterNode, SingleClusterNode.is_root.__name__, return_value=False)
+    @patch("make_prg.recursion_tree.kmeans_cluster_seqs", return_value=Mock(have_precomputed_sequences=True,
+                                                                            sequences=["TGCA"]))
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___single_interval_and_single_seq___not_root_and_have_precomputed_sequences(self,
+                                                                                                     update_prg_index_mock,
+                                                                                                     *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 0)]
+
+        expected_prg_as_list = list("TGCA")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        update_prg_index_mock.assert_called_once_with(0, 4, node=self.single_cluster_node)
+
+    @patch.object(SequenceExpander, SequenceExpander.get_expanded_sequences_from_MSA.__name__, return_value=[
+        "AA", "C", "GGGG"])
+    @patch.object(PrgBuilder, PrgBuilder.get_next_site_num.__name__, return_value=42)
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___single_interval_and_several_seqs(self, update_prg_index_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [Interval(IntervalType.Match, 0, 0)]
+
+        expected_prg_as_list = list("*42*AA*43*C*43*GGGG*42*")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        self.assertEqual(3, update_prg_index_mock.call_count)
+        update_prg_index_mock.assert_any_call(4, 6, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(10, 11, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(15, 19, node=self.single_cluster_node)
+
+    @patch.object(SequenceExpander, SequenceExpander.get_expanded_sequences_from_MSA.__name__, side_effect=[
+        ["ACGT"],
+        ["AA", "C", "GGGG"],
+        ["TTTT"],
+        ["G", "T"]
+    ])
+    @patch.object(SingleClusterNode, SingleClusterNode._init_pre_recursion_attributes.__name__)
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__)
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___several_intervals___single_and_multiple_seqs_intertwinned(self, update_prg_index_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [
+            Interval(IntervalType.Match, 0, 0),
+            Interval(IntervalType.Match, 1, 1),
+            Interval(IntervalType.Match, 2, 2),
+            Interval(IntervalType.Match, 3, 3),
+        ]
+        self.single_cluster_node.prg_builder.site_num = 42
+
+        expected_prg_as_list = list("ACGT*42*AA*43*C*43*GGGG*42*TTTT*44*G*45*T*44*")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        self.assertEqual(7, update_prg_index_mock.call_count)
+        update_prg_index_mock.assert_any_call(0, 4, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(8, 10, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(14, 15, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(19, 23, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(27, 31, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(35, 36, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(40, 41, node=self.single_cluster_node)
+
+
+    @patch.object(SequenceExpander, SequenceExpander.get_expanded_sequences_from_MSA.__name__, side_effect=[
+        ["AA"],
+        ["CCCC"],
+        ["G"]
+    ])
+    @patch.object(SingleClusterNode, SingleClusterNode._init_pre_recursion_attributes.__name__)
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__)
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___several_intervals___all_single_seqs(self, update_prg_index_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [
+            Interval(IntervalType.Match, 0, 0),
+            Interval(IntervalType.Match, 1, 1),
+            Interval(IntervalType.Match, 2, 2),
+        ]
+        self.single_cluster_node.prg_builder.site_num = 42
+
+        expected_prg_as_list = list("AACCCCG")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        self.assertEqual(3, update_prg_index_mock.call_count)
+
+        # TODO: updates are very likely made much better if we can join all these intervals together
+        update_prg_index_mock.assert_any_call(0, 2, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(2, 6, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(6, 7, node=self.single_cluster_node)
+
+    @patch.object(SequenceExpander, SequenceExpander.get_expanded_sequences_from_MSA.__name__, side_effect=[
+        ["AA", "C", "GGGG"],
+        ["G", "T"],
+        ["A", "C"],
+    ])
+    @patch.object(SingleClusterNode, SingleClusterNode._init_pre_recursion_attributes.__name__)
+    @patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__)
+    @patch.object(PrgBuilder, PrgBuilder.update_PRG_index.__name__)
+    def test___get_prg___several_intervals___all_several_seqs(self, update_prg_index_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.all_intervals = [
+            Interval(IntervalType.Match, 0, 0),
+            Interval(IntervalType.Match, 1, 1),
+            Interval(IntervalType.Match, 2, 2),
+        ]
+        self.single_cluster_node.prg_builder.site_num = 42
+
+        expected_prg_as_list = list("*42*AA*43*C*43*GGGG*42**44*G*45*T*44**46*A*47*C*46*")
+        actual_prg_as_list = []
+        self.single_cluster_node._get_prg(actual_prg_as_list, delim_char="*")
+
+        self.assertEqual(expected_prg_as_list, actual_prg_as_list)
+        self.assertEqual(7, update_prg_index_mock.call_count)
+
+        update_prg_index_mock.assert_any_call(4, 6, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(10, 11, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(15, 19, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(27, 28, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(32, 33, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(41, 42, node=self.single_cluster_node)
+        update_prg_index_mock.assert_any_call(46, 47, node=self.single_cluster_node)
+
+
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_prg.__name__)
+    def test___preorder_traversal_to_build_prg___no_children___compute_PRG(self, get_prg_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node._children = []
+        prg_as_list = []
+
+        self.single_cluster_node.preorder_traversal_to_build_prg(prg_as_list, delim_char="*")
+
+        get_prg_mock.assert_called_once_with(prg_as_list, "*")
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_prg.__name__)
+    def test___preorder_traversal_to_build_prg___one_child___recursion_happens(self, get_prg_mock, *uninteresting_mocks):
+        self.setup()
+        preorder_traversal_to_build_prg_mock = Mock()
+        child = Mock(preorder_traversal_to_build_prg=preorder_traversal_to_build_prg_mock)
+        self.single_cluster_node._children = [child]
+        prg_as_list = []
+
+        self.single_cluster_node.preorder_traversal_to_build_prg(prg_as_list, delim_char="*")
+
+        get_prg_mock.assert_not_called()
+        preorder_traversal_to_build_prg_mock.assert_called_once_with(prg_as_list, "*")
+
+    @patch.object(SingleClusterNode, SingleClusterNode._get_prg.__name__)
+    def test___preorder_traversal_to_build_prg___several_children___recursion_happens(self, get_prg_mock,
+                                                                               *uninteresting_mocks):
+        self.setup()
+        preorder_traversal_to_build_prg_mock_1 = Mock()
+        child_1 = Mock(preorder_traversal_to_build_prg=preorder_traversal_to_build_prg_mock_1)
+        preorder_traversal_to_build_prg_mock_2 = Mock()
+        child_2 = Mock(preorder_traversal_to_build_prg=preorder_traversal_to_build_prg_mock_2)
+        preorder_traversal_to_build_prg_mock_3 = Mock()
+        child_3 = Mock(preorder_traversal_to_build_prg=preorder_traversal_to_build_prg_mock_3)
+        self.single_cluster_node._children = [child_1, child_2, child_3]
+        prg_as_list = []
+
+        self.single_cluster_node.preorder_traversal_to_build_prg(prg_as_list, delim_char="*")
+
+        get_prg_mock.assert_not_called()
+        preorder_traversal_to_build_prg_mock_1.assert_called_once_with(prg_as_list, "*")
+        preorder_traversal_to_build_prg_mock_2.assert_called_once_with(prg_as_list, "*")
+        preorder_traversal_to_build_prg_mock_3.assert_called_once_with(prg_as_list, "*")
+
+    def test___add_data_to_batch_update___interval_not_indexed___raises_UpdateError(self, *uninteresting_mocks):
+        self.setup()
+        ml_path_mock = Mock()
+        update_data = UpdateData((0, 4), ml_path_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        with self.assertRaises(UpdateError):
+            self.single_cluster_node.add_data_to_batch_update(update_data)
+
+    def test___add_data_to_batch_update___single_interval(self, *uninteresting_mocks):
+        self.setup()
+        ml_path_mock = Mock()
+        update_data = UpdateData((0, 4), ml_path_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {(0, 4)}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        self.single_cluster_node.add_data_to_batch_update(update_data)
+
+        expected = {"ACGT"}
+        self.assertEqual(expected, self.single_cluster_node.new_sequences)
+
+    def test___add_data_to_batch_update___update_data_interval_flanked(self, *uninteresting_mocks):
+        self.setup()
+
+        def get_node_given_interval_in_PRG_space_mock_fun(interval):
+            if interval == (0, 4):
+                return Mock(sequence="left_flank")
+            elif interval == (20, 30):
+                return Mock(sequence="right_flank")
+            else:
+                assert False, "Error on get_node_given_interval_in_PRG_space_mock_fun"
+
+        get_node_given_interval_in_PRG_space_mock = Mock(side_effect=get_node_given_interval_in_PRG_space_mock_fun)
+        ml_path_node_mock = Mock(get_node_given_interval_in_PRG_space = get_node_given_interval_in_PRG_space_mock)
+        update_data = UpdateData((5, 10), ml_path_node_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {(5, 10), (20, 30), (0, 4)}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        self.single_cluster_node.add_data_to_batch_update(update_data)
+
+        expected = {"left_flankACGTright_flank"}
+        self.assertEqual(expected, self.single_cluster_node.new_sequences)
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((0, 4))
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((20, 30))
+
+    def test___add_data_to_batch_update___update_data_interval_on_the_left_end(self, *uninteresting_mocks):
+        self.setup()
+
+        def get_node_given_interval_in_PRG_space_mock_fun(interval):
+            if interval == (5, 10):
+                return Mock(sequence="middle_flank")
+            elif interval == (20, 30):
+                return Mock(sequence="right_flank")
+            else:
+                assert False, "Error on get_node_given_interval_in_PRG_space_mock_fun"
+
+        get_node_given_interval_in_PRG_space_mock = Mock(side_effect=get_node_given_interval_in_PRG_space_mock_fun)
+        ml_path_node_mock = Mock(get_node_given_interval_in_PRG_space = get_node_given_interval_in_PRG_space_mock)
+        update_data = UpdateData((0, 4), ml_path_node_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {(5, 10), (20, 30), (0, 4)}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        self.single_cluster_node.add_data_to_batch_update(update_data)
+
+        expected = {"ACGTmiddle_flankright_flank"}
+        self.assertEqual(expected, self.single_cluster_node.new_sequences)
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((5, 10))
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((20, 30))
+
+    def test___add_data_to_batch_update___update_data_interval_on_the_right_end(self, *uninteresting_mocks):
+        self.setup()
+
+        def get_node_given_interval_in_PRG_space_mock_fun(interval):
+            if interval == (0, 4):
+                return Mock(sequence="left_flank")
+            elif interval == (5, 10):
+                return Mock(sequence="middle_flank")
+            else:
+                assert False, "Error on get_node_given_interval_in_PRG_space_mock_fun"
+
+        get_node_given_interval_in_PRG_space_mock = Mock(side_effect=get_node_given_interval_in_PRG_space_mock_fun)
+        ml_path_node_mock = Mock(get_node_given_interval_in_PRG_space = get_node_given_interval_in_PRG_space_mock)
+        update_data = UpdateData((20, 30), ml_path_node_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {(5, 10), (20, 30), (0, 4)}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        self.single_cluster_node.add_data_to_batch_update(update_data)
+
+        expected = {"left_flankmiddle_flankACGT"}
+        self.assertEqual(expected, self.single_cluster_node.new_sequences)
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((0, 4))
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((5, 10))
+
+    def test___add_data_to_batch_update___update_data_interval_flanked___left_interval_not_in_ml_path(self, *uninteresting_mocks):
+        self.setup()
+
+        def get_node_given_interval_in_PRG_space_mock_fun(interval):
+            if interval == (20, 30):
+                return Mock(sequence="right_flank")
+            else:
+                raise MLPathError()
+
+        get_node_given_interval_in_PRG_space_mock = Mock(side_effect=get_node_given_interval_in_PRG_space_mock_fun)
+        ml_path_node_mock = Mock(get_node_given_interval_in_PRG_space = get_node_given_interval_in_PRG_space_mock)
+        update_data = UpdateData((5, 10), ml_path_node_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {(5, 10), (20, 30), (0, 4)}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        self.single_cluster_node.add_data_to_batch_update(update_data)
+
+        expected = {"ACGTright_flank"}
+        self.assertEqual(expected, self.single_cluster_node.new_sequences)
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((0, 4))
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((20, 30))
+
+    def test___add_data_to_batch_update___update_data_interval_flanked___right_interval_not_in_ml_path(self, *uninteresting_mocks):
+        self.setup()
+
+        def get_node_given_interval_in_PRG_space_mock_fun(interval):
+            if interval == (0, 4):
+                return Mock(sequence="left_flank")
+            else:
+                raise MLPathError()
+
+        get_node_given_interval_in_PRG_space_mock = Mock(side_effect=get_node_given_interval_in_PRG_space_mock_fun)
+        ml_path_node_mock = Mock(get_node_given_interval_in_PRG_space = get_node_given_interval_in_PRG_space_mock)
+        update_data = UpdateData((5, 10), ml_path_node_mock, "ACGT")
+        self.single_cluster_node.indexed_PRG_intervals = {(5, 10), (20, 30), (0, 4)}
+        self.assertEqual(set(), self.single_cluster_node.new_sequences)
+
+        self.single_cluster_node.add_data_to_batch_update(update_data)
+
+        expected = {"left_flankACGT"}
+        self.assertEqual(expected, self.single_cluster_node.new_sequences)
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((0, 4))
+        get_node_given_interval_in_PRG_space_mock.assert_any_call((20, 30))
+
+    def test___add_indexed_PRG_interval___single_interval(self, *uninteresting_mocks):
+        self.setup()
+
+        self.assertEqual(set(), self.single_cluster_node.indexed_PRG_intervals)
+        self.single_cluster_node.add_indexed_PRG_interval((0, 4))
+        self.assertEqual({(0, 4)}, self.single_cluster_node.indexed_PRG_intervals)
+
+    def test___add_indexed_PRG_interval___multiple_intervals(self, *uninteresting_mocks):
+        self.setup()
+
+        self.assertEqual(set(), self.single_cluster_node.indexed_PRG_intervals)
+        self.single_cluster_node.add_indexed_PRG_interval((0, 4))
+        self.single_cluster_node.add_indexed_PRG_interval((25, 30))
+        self.single_cluster_node.add_indexed_PRG_interval((0, 4))
+        self.single_cluster_node.add_indexed_PRG_interval((0, 4))
+        self.single_cluster_node.add_indexed_PRG_interval((25, 30))
+        self.single_cluster_node.add_indexed_PRG_interval((10, 15))
+        self.single_cluster_node.add_indexed_PRG_interval((25, 30))
+        self.single_cluster_node.add_indexed_PRG_interval((0, 4))
+        self.single_cluster_node.add_indexed_PRG_interval((17, 19))
+        self.assertEqual({(0, 4), (10, 15), (17, 19), (25, 30)},
+                         self.single_cluster_node.indexed_PRG_intervals)
+
+    @patch.object(SingleClusterNode, SingleClusterNode._update_leaf.__name__)
+    def test___batch_update___no_new_sequences___no_update_to_be_done(self, update_leaf_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.batch_update()
+        update_leaf_mock.assert_not_called()
+
+    @patch.object(SingleClusterNode, SingleClusterNode._update_leaf.__name__)
+    def test___batch_update___one_new_sequence___update_is_called(self, update_leaf_mock, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.new_sequences.add("ACGT")
+        self.single_cluster_node.batch_update()
+        update_leaf_mock.assert_called_once_with()
+
+    def test___update_leaf___no_aligner_was_given___raises_AssertionError(self, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node.new_sequences.add("ACGT")
+        with self.assertRaises(AssertionError):
+            self.single_cluster_node._update_leaf()
+
+    def test___update_leaf(self, init_pre_recursion_attributes_mock, *uninteresting_mocks):
+        self.setup()
+
+        update_alignment = Mock()
+        get_updated_alignment_mock = Mock(return_value=update_alignment)
+        aligner_mock = Mock()
+        aligner_mock.get_updated_alignment = get_updated_alignment_mock
+        self.prg_builder.aligner = aligner_mock
+
+        self.single_cluster_node.new_sequences.add("AAAA")
+        self.single_cluster_node.new_sequences.add("CC")
+
+        # we repatch some stuff to check the calls on the _update_leaf() only
+        with patch.object(SingleClusterNode, SingleClusterNode._get_children.__name__, return_value=["updated_child_1", "updated_child_2"]) as get_children_mock, \
+             patch.object(SingleClusterNode, SingleClusterNode._init_pre_recursion_attributes.__name__) as init_pre_recursion_attributes_mock:
+            self.single_cluster_node._update_leaf()
+
+            # assert_called_once_with() does not work because can't check if MSAs are equal
+            get_updated_alignment_mock.assert_called_once()
+            kwargs = get_updated_alignment_mock.call_args_list[0].kwargs
+            self.assertTrue(equal_msas(self.alignment, kwargs["current_alignment"]))
+            self.assertEqual({"AAAA", "CC"}, kwargs["new_sequences"])
+
+            init_pre_recursion_attributes_mock.assert_called_once_with()
+            get_children_mock.assert_called_once_with()
+
+            # lets check all attributes anyway, except the ones initialised by init_pre_recursion_attributes()
+            self.assertEqual(1, self.single_cluster_node.nesting_level)
+            self.assertTrue(update_alignment, self.single_cluster_node.alignment)
+            self.assertIsNone(self.single_cluster_node.parent)
+            self.assertEqual(self.prg_builder, self.single_cluster_node.prg_builder)
+            self.assertFalse(self.single_cluster_node.force_no_child)
+            self.assertEqual(0, self.single_cluster_node.id)
+            self.assertEqual(["updated_child_1", "updated_child_2"], self.single_cluster_node.children)
+
+    def test___repr_and_str(self, *uninteresting_mocks):
+        self.setup()
+        self.single_cluster_node._children = [Mock(id=100), Mock(id=200)]
+        expected = """SingleClusterNode:
+Id = 0
+Nesting level = 1
+Force no child = False
+Parent = None
+Children = [Id = 100, Id = 200]
+Alignment:
+>s1
+AAAT
+>s2
+C--C
+>s3
+AATT
+>s4
+GNGG
+Consensus: ****
+Match intervals: []
+Non-match intervals: [[0, 3]]
+"""
+        actual = repr(self.single_cluster_node)
+        self.assertEqual(expected, actual)
+
+        actual = str(self.single_cluster_node)
+        self.assertEqual(expected, actual)

--- a/tests/test_recursion_tree.py
+++ b/tests/test_recursion_tree.py
@@ -702,7 +702,7 @@ class TestNodeFactory(TestCase):
             self.prg_builder = PrgBuilder("locus", Path("msa"), "fasta", 5, 7)
         self.parent_mock = Mock(id=512)
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=False)
     @patch.object(NodeFactory, NodeFactory._partition_alignment_into_interval_subalignments.__name__,
                   return_value = "interval_subalignments_mock")
@@ -721,7 +721,7 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, None)
             self.assertTrue(isinstance(node, MultiIntervalNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=True)
@@ -741,7 +741,7 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, None)
             self.assertTrue(isinstance(node, MultiClusterNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=False)
@@ -759,7 +759,7 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, None)
             self.assertTrue(isinstance(node, LeafNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=False)
     @patch.object(NodeFactory, NodeFactory._partition_alignment_into_interval_subalignments.__name__,
                   return_value="interval_subalignments_mock")
@@ -784,7 +784,7 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
             self.assertTrue(isinstance(node, MultiIntervalNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=False)
@@ -807,7 +807,7 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
             self.assertTrue(isinstance(node, LeafNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=True)
@@ -835,7 +835,7 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
             self.assertTrue(isinstance(node, MultiClusterNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_all_and_match_intervals.__name__, return_value=(Mock(), Mock()))
+    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
     @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=False)
@@ -960,10 +960,10 @@ class TestNodeFactory(TestCase):
         alignment_mock.get_alignment_length = Mock(return_value=7)
         self.assertFalse(NodeFactory._infer_if_has_single_interval([], [], 4, 5, alignment_mock, 7))
 
-    def test___get_all_and_match_intervals(self, *uninteresting_mocks):
+    def test___get_vertical_partition(self, *uninteresting_mocks):
         msa = make_alignment(["AAAAATTTTTGGGGG", "AAAAACCCCCGGGGG"])
 
-        all_intervals, match_intervals = NodeFactory._get_all_and_match_intervals(msa, 3)
+        all_intervals, match_intervals = NodeFactory._get_vertical_partition(msa, 3)
 
         first_interval = Interval(IntervalType.Match, 0, 4)
         second_interval = Interval(IntervalType.NonMatch, 5, 9)

--- a/tests/test_recursion_tree.py
+++ b/tests/test_recursion_tree.py
@@ -703,7 +703,7 @@ class TestNodeFactory(TestCase):
         self.parent_mock = Mock(id=512)
 
     @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=False)
+    @patch.object(NodeFactory, NodeFactory._is_single_match_interval.__name__, return_value=False)
     @patch.object(NodeFactory, NodeFactory._partition_alignment_into_interval_subalignments.__name__,
                   return_value = "interval_subalignments_mock")
     def test___build___root___multi_interval(self, *uninteresting_mocks):
@@ -722,29 +722,7 @@ class TestNodeFactory(TestCase):
             self.assertTrue(isinstance(node, MultiIntervalNode))
 
     @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
-    @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
-    @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=True)
-    @patch.object(NodeFactory, NodeFactory._get_subalignments_by_clustering.__name__, return_value="get_subalignments_by_clustering_mock")
-    def test___build___root___multi_cluster(self, *uninteresting_mocks):
-        self.setup()
-
-        # mock MultiClusterNode.__init__
-        def __init__(node_self, nesting_level, alignment, parent, prg_builder, interval_subalignments):
-            self.assertEqual(0, nesting_level)
-            self.assertEqual(self.alignment, alignment)
-            self.assertEqual(None, parent)
-            self.assertEqual(self.prg_builder, prg_builder)
-            self.assertEqual("get_subalignments_by_clustering_mock", interval_subalignments)
-
-        with patch.object(MultiClusterNode, '__init__', __init__):
-            node = NodeFactory.build(self.alignment, self.prg_builder, None)
-            self.assertTrue(isinstance(node, MultiClusterNode))
-
-    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
-    @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
-    @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=False)
+    @patch.object(NodeFactory, NodeFactory._is_single_match_interval.__name__, return_value=True)
     def test___build___root___leaf(self, *uninteresting_mocks):
         self.setup()
 
@@ -760,7 +738,7 @@ class TestNodeFactory(TestCase):
             self.assertTrue(isinstance(node, LeafNode))
 
     @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=False)
+    @patch.object(NodeFactory, NodeFactory._is_single_match_interval.__name__, return_value=False)
     @patch.object(NodeFactory, NodeFactory._partition_alignment_into_interval_subalignments.__name__,
                   return_value="interval_subalignments_mock")
     def test___build___non_root___parent_is_multi_cluster_creates_multi_interval(self, *uninteresting_mocks):
@@ -774,7 +752,7 @@ class TestNodeFactory(TestCase):
 
         # mock MultiIntervalNode.__init__
         def __MultiIntervalNode_init__(node_self, nesting_level, alignment, parent, prg_builder, interval_subalignments):
-            self.assertEqual(5, nesting_level)
+            self.assertEqual(4, nesting_level)
             self.assertEqual(self.alignment, alignment)
             self.assertEqual(outer_parent, parent)
             self.assertEqual(self.prg_builder, prg_builder)
@@ -785,9 +763,7 @@ class TestNodeFactory(TestCase):
             self.assertTrue(isinstance(node, MultiIntervalNode))
 
     @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
-    @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
-    @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=False)
+    @patch.object(NodeFactory, NodeFactory._is_single_match_interval.__name__, return_value=True)
     def test___build___non_root___parent_is_multi_cluster_creates_leaf(self, *uninteresting_mocks):
         self.setup()
 
@@ -799,7 +775,7 @@ class TestNodeFactory(TestCase):
 
         # mock Leaf.__init__
         def __Leaf_init__(node_self, nesting_level, alignment, parent, prg_builder):
-            self.assertEqual(5, nesting_level)
+            self.assertEqual(4, nesting_level)
             self.assertEqual(self.alignment, alignment)
             self.assertEqual(outer_parent, parent)
             self.assertEqual(self.prg_builder, prg_builder)
@@ -807,8 +783,6 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
             self.assertTrue(isinstance(node, LeafNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=True)
     @patch.object(NodeFactory, NodeFactory._get_subalignments_by_clustering.__name__,
@@ -825,7 +799,7 @@ class TestNodeFactory(TestCase):
         # mock MultiClusterNode.__init__
         def __MultiClusterNode_init__(node_self, nesting_level, alignment, parent, prg_builder,
                                        cluster_subalignments):
-            self.assertEqual(4, nesting_level)
+            self.assertEqual(5, nesting_level)
             self.assertEqual(self.alignment, alignment)
             self.assertEqual(outer_parent, parent)
             self.assertEqual(self.prg_builder, prg_builder)
@@ -835,8 +809,6 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
             self.assertTrue(isinstance(node, MultiClusterNode))
 
-    @patch.object(NodeFactory, NodeFactory._get_vertical_partition.__name__, return_value=(Mock(), Mock()))
-    @patch.object(NodeFactory, NodeFactory._infer_if_has_single_interval.__name__, return_value=True)
     @patch("make_prg.recursion_tree.kmeans_cluster_seqs")
     @patch.object(NodeFactory, NodeFactory._infer_if_we_should_cluster_further.__name__, return_value=False)
     def test___build___non_root___parent_is_multi_interval_creates_leaf(self, *uninteresting_mocks):
@@ -859,16 +831,17 @@ class TestNodeFactory(TestCase):
             node = NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
             self.assertTrue(isinstance(node, LeafNode))
 
-    def test___build___non_root___parent_is_leaf_AssertionError_is_raised(self, *uninteresting_mocks):
+    def test___build___non_root___parent_is_leaf_ValueError_is_raised(self, *uninteresting_mocks):
         self.setup()
 
         # mock LeafNode.__init__
-        with patch.object(LeafNode, '__init__', return_value=None):
-            outer_parent = LeafNode()
+        def __LeafNode_init__(node_self, nesting_level):
+            node_self.nesting_level = nesting_level
+        with patch.object(LeafNode, '__init__', __LeafNode_init__):
+            outer_parent = LeafNode(4)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             NodeFactory.build(self.alignment, self.prg_builder, outer_parent)
-
 
     @patch("make_prg.recursion_tree.get_number_of_unique_ungapped_sequences", return_value=1)
     def test___alignment_has_issues___too_few_unique_sequences_1(self,
@@ -910,56 +883,6 @@ class TestNodeFactory(TestCase):
         with self.assertRaises(AssertionError):
             NodeFactory._alignment_has_issues(self.alignment)
 
-    def test___get_nesting_level___no_parent(self, *uninteresting_mocks):
-        self.setup()
-        expected = 0
-        actual = NodeFactory._get_nesting_level(None)
-
-        self.assertEqual(expected, actual)
-
-    @patch.object(MultiClusterNode, MultiClusterNode.is_leaf.__name__, return_value=False)
-    def test___get_nesting_level___parent_is_MultiClusterNode(self, *uninteresting_mocks):
-        self.setup()
-        parent = MultiClusterNode(3, self.alignment, self.parent_mock, self.prg_builder, [])
-
-        expected = 4
-        actual = NodeFactory._get_nesting_level(parent)
-
-        self.assertEqual(expected, actual)
-
-    @patch.object(MultiIntervalNode, MultiIntervalNode.is_leaf.__name__, return_value=False)
-    def test___get_nesting_level___parent_is_MultiIntervalNode(self, *uninteresting_mocks):
-        self.setup()
-        parent = MultiIntervalNode(3, self.alignment, self.parent_mock, self.prg_builder, [])
-
-        expected = 3
-        actual = NodeFactory._get_nesting_level(parent)
-
-        self.assertEqual(expected, actual)
-
-    def test___infer_if_has_single_interval___single_match_interval(self, *uninteresting_mocks):
-        interval = Interval(IntervalType.Match, 3, 10)
-        all_intervals = [interval]
-        match_intervals = [interval]
-        self.assertTrue(NodeFactory._infer_if_has_single_interval(
-            all_intervals, match_intervals, 1, 5, None, 7
-        ))
-
-    def test___infer_if_has_single_interval___max_nesting_level_reached(self, *uninteresting_mocks):
-        self.assertTrue(NodeFactory._infer_if_has_single_interval([], [], 5, 5, None, 7))
-
-    def test___infer_if_has_single_interval___small_variant_site(self, *uninteresting_mocks):
-        alignment_mock = Mock()
-        alignment_mock.get_alignment_length = Mock(return_value=6)
-        self.assertTrue(NodeFactory._infer_if_has_single_interval([], [], 4, 5, alignment_mock, 7))
-        alignment_mock.get_alignment_length.assert_called_once_with()
-
-    def test___infer_if_has_single_interval___has_multiple_intervals(self,
-            alignment_has_issues_mock, *uninteresting_mocks):
-        alignment_mock = Mock()
-        alignment_mock.get_alignment_length = Mock(return_value=7)
-        self.assertFalse(NodeFactory._infer_if_has_single_interval([], [], 4, 5, alignment_mock, 7))
-
     def test___get_vertical_partition(self, *uninteresting_mocks):
         msa = make_alignment(["AAAAATTTTTGGGGG", "AAAAACCCCCGGGGG"])
 
@@ -972,6 +895,43 @@ class TestNodeFactory(TestCase):
         expected_match_intervals = [first_interval, third_interval]
         self.assertEqual(expected_all_intervals, all_intervals)
         self.assertEqual(expected_match_intervals, match_intervals)
+
+    def test___is_single_match_interval___single_match_interval(self, *uninteresting_mocks):
+        interval = Interval(IntervalType.Match, 3, 10)
+        all_intervals = [interval]
+        match_intervals = [interval]
+        self.assertTrue(NodeFactory._is_single_match_interval(all_intervals, match_intervals))
+
+    def test___is_single_match_interval___no_intervals(self, *uninteresting_mocks):
+        self.assertFalse(NodeFactory._is_single_match_interval([], []))
+
+    def test___is_single_match_interval___two_match_intervals(self, *uninteresting_mocks):
+        interval_1 = Interval(IntervalType.Match, 3, 10)
+        interval_2 = Interval(IntervalType.Match, 30, 100)
+        all_intervals = [interval_1, interval_2]
+        match_intervals = [interval_1, interval_2]
+        self.assertFalse(NodeFactory._is_single_match_interval(all_intervals, match_intervals))
+
+    def test___is_single_match_interval___single_mismatch_interval(self, *uninteresting_mocks):
+        interval_1 = Interval(IntervalType.NonMatch, 3, 10)
+        all_intervals = [interval_1]
+        match_intervals = []
+        self.assertFalse(NodeFactory._is_single_match_interval(all_intervals, match_intervals))
+
+    def test___is_single_match_interval___two_mismatch_intervals(self, *uninteresting_mocks):
+        interval_1 = Interval(IntervalType.NonMatch, 3, 10)
+        interval_2 = Interval(IntervalType.NonMatch, 30, 100)
+        all_intervals = [interval_1, interval_2]
+        match_intervals = []
+        self.assertFalse(NodeFactory._is_single_match_interval(all_intervals, match_intervals))
+
+    def test___is_single_match_interval___single_match_interval_but_two_intervals(self, *uninteresting_mocks):
+        interval_1 = Interval(IntervalType.Match, 3, 10)
+        interval_2 = Interval(IntervalType.NonMatch, 30, 100)
+        all_intervals = [interval_1, interval_2]
+        match_intervals = [interval_1]
+        self.assertFalse(NodeFactory._is_single_match_interval(all_intervals, match_intervals))
+
 
     def test___partition_alignment_into_interval_subalignments(self, *uninteresting_mocks):
         msa = make_alignment(["AAAAATTTTTGGGGG", "AAAAACCCCCGGGGG"])
@@ -992,21 +952,36 @@ class TestNodeFactory(TestCase):
 
     def test___infer_if_we_should_cluster_further___no_clustering(self, *uninteresting_mocks):
         clustering_result_mock = Mock(no_clustering=True)
-        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(Mock(), clustering_result_mock))
+        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(Mock(), clustering_result_mock, 3, 5))
+
+    def test___infer_if_we_should_cluster_further___max_nesting_reached___smaller(self, *uninteresting_mocks):
+        clustering_result_mock = Mock(no_clustering=False)
+        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(Mock(), clustering_result_mock, 4, 5))
+
+    def test___infer_if_we_should_cluster_further___max_nesting_reached___equal(self, *uninteresting_mocks):
+        clustering_result_mock = Mock(no_clustering=False)
+        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(Mock(), clustering_result_mock, 5, 5))
+
+    def test___infer_if_we_should_cluster_further___max_nesting_reached___larger(self, *uninteresting_mocks):
+        clustering_result_mock = Mock(no_clustering=False)
+        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(Mock(), clustering_result_mock, 6, 5))
 
     @patch.object(NodeFactory, NodeFactory._alignment_has_issues.__name__, return_value=True)
     def test___infer_if_we_should_cluster_further___alignment_has_issues(self,
          alignment_has_issues_mock, *uninteresting_mocks):
         clustering_result_mock = Mock(no_clustering=False)
         alignment_mock = Mock()
-        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(alignment_mock, clustering_result_mock))
+        self.assertFalse(NodeFactory._infer_if_we_should_cluster_further(alignment_mock, clustering_result_mock, 3, 5))
         alignment_has_issues_mock.assert_called_once_with(alignment_mock)
 
     @patch.object(NodeFactory, NodeFactory._alignment_has_issues.__name__, return_value=False)
-    def test___infer_if_we_should_cluster_further___no_issues___ok_to_cluster_further(self, *uninteresting_mocks):
+    def test___infer_if_we_should_cluster_further___no_issues___ok_to_cluster(self,
+                                                                              alignment_has_issues_mock,
+                                                                              *uninteresting_mocks):
         clustering_result_mock = Mock(no_clustering=False)
         alignment_mock = Mock()
-        self.assertTrue(NodeFactory._infer_if_we_should_cluster_further(alignment_mock, clustering_result_mock))
+        self.assertTrue(NodeFactory._infer_if_we_should_cluster_further(alignment_mock, clustering_result_mock, 3, 5))
+        alignment_has_issues_mock.assert_called_once_with(alignment_mock)
 
     def test___get_subalignments_by_clustering(self, *uninteresting_mocks):
         alignment = make_alignment(

--- a/tests/update/test_DenovoLocusInfo.py
+++ b/tests/update/test_DenovoLocusInfo.py
@@ -1,0 +1,161 @@
+from unittest import TestCase
+from make_prg.update.MLPath import MLPathNode, MLPath, MLPathError
+from make_prg.update.denovo_variants import DenovoVariant, DenovoLocusInfo, UpdateData
+
+
+class DenovoLocusInfoTest(TestCase):
+    def setUp(self):
+        self.ml_path_node_1 = MLPathNode(key=(5, 9), sequence="ACGT")
+        self.ml_path_node_2 = MLPathNode(key=(12, 13), sequence="G")
+        self.ml_path_node_3 = MLPathNode(key=(20, 22), sequence="AA")
+        self.ml_path_nodes = [self.ml_path_node_1, self.ml_path_node_2, self.ml_path_node_3]
+        self.ml_path = MLPath(self.ml_path_nodes)
+
+
+    def test___get_ml_path_nodes_spanning_variant___strict_insertion_event(self):
+        denovo_variant = DenovoVariant(2, "", "ACGT")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_1]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_one_base_of_first_node(self):
+        denovo_variant = DenovoVariant(0, "A", "ACGT")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_1]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_all_bases_of_first_node(self):
+        denovo_variant = DenovoVariant(0, "ACGT", "GGGG")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_1, self.ml_path_node_1, self.ml_path_node_1, self.ml_path_node_1]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_all_bases_of_second_node(self):
+        denovo_variant = DenovoVariant(4, "G", "AAA")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_2]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_last_base_of_third_node(self):
+        denovo_variant = DenovoVariant(6, "A", "T")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_3]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_all_bases_of_third_node(self):
+        denovo_variant = DenovoVariant(5, "AA", "T")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_3, self.ml_path_node_3]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_all_nodes(self):
+        denovo_variant = DenovoVariant(0, "ACGTGAA", "T")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_1, self.ml_path_node_1, self.ml_path_node_1, self.ml_path_node_1,
+                    self.ml_path_node_2, self.ml_path_node_3, self.ml_path_node_3]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_all_nodes_on_border(self):
+        denovo_variant = DenovoVariant(3, "TGA", "")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_1, self.ml_path_node_2, self.ml_path_node_3]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_spanning_last_base_and_an_additional_base_of_third_node___raises_MLPathError(self):
+        denovo_variant = DenovoVariant(6, "AA", "T")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+        with self.assertRaises(MLPathError):
+            denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_is_a_strict_insertion_at_the_last_insertion_position(self):
+        denovo_variant = DenovoVariant(7, "", "AAA")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+
+        expected = [self.ml_path_node_3]
+        actual = denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+        self.assertEqual(expected, actual)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_is_a_strict_insertion_one_base_after_the_last_insertion_position___raises_MLPathError(self):
+        denovo_variant = DenovoVariant(8, "", "AAA")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+        with self.assertRaises(MLPathError):
+            denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+    def test___get_ml_path_nodes_spanning_variant___variant_is_a_non_strict_insertion_at_the_last_insertion_position___raises_MLPathError(self):
+        denovo_variant = DenovoVariant(7, "A", "AAA")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+        with self.assertRaises(MLPathError):
+            denovo_locus_info._get_ml_path_nodes_spanning_variant(denovo_variant)
+
+    def test___get_update_data___empty_variants___returns_empty_update_data(self):
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [])
+        expected = []
+        actual = denovo_locus_info.get_update_data()
+        self.assertEqual(expected, actual)
+
+    def test___get_update_data___several_variants_in_first_node(self):
+        denovo_variant = DenovoVariant(0, "ACGT", "TT")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [denovo_variant])
+
+        expected = [UpdateData(self.ml_path_node_1.key, self.ml_path, "TT")]
+        actual = denovo_locus_info.get_update_data()
+
+        self.assertEqual(expected, actual)
+
+
+    def test___get_update_data___indels_in_last_node(self):
+        denovo_variant = DenovoVariant(5, "AA", "ATTTTT")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [denovo_variant])
+
+        expected = [UpdateData(self.ml_path_node_3.key, self.ml_path, "ATTTTT")]
+        actual = denovo_locus_info.get_update_data()
+
+        self.assertEqual(expected, actual)
+
+
+    def test___get_update_data___one_SNP_in_each_node(self):
+        denovo_variant = DenovoVariant(0, "ACGTGAA", "AGGTCAT")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [denovo_variant])
+
+        expected = [UpdateData(self.ml_path_node_1.key, self.ml_path, "AGGT"),
+                    UpdateData(self.ml_path_node_2.key, self.ml_path, "C"),
+                    UpdateData(self.ml_path_node_3.key, self.ml_path, "AT")]
+        actual = denovo_locus_info.get_update_data()
+
+        self.assertEqual(expected, actual)
+
+    def test___get_update_data___one_SNP_in_each_node_border_only(self):
+        denovo_variant = DenovoVariant(3, "TGA", "CCC")
+        denovo_locus_info = DenovoLocusInfo("sample", "locus", self.ml_path, [denovo_variant])
+
+        expected = [UpdateData(self.ml_path_node_1.key, self.ml_path, "ACGC"),
+                    UpdateData(self.ml_path_node_2.key, self.ml_path, "C"),
+                    UpdateData(self.ml_path_node_3.key, self.ml_path, "CA")]
+        actual = denovo_locus_info.get_update_data()
+
+        self.assertEqual(expected, actual)

--- a/tests/update/test_DenovoVariant.py
+++ b/tests/update/test_DenovoVariant.py
@@ -1,0 +1,472 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from make_prg.update.denovo_variants import DenovoVariant, DenovoError
+from make_prg.update.MLPath import MLPathNode
+
+class DenovoVariantTest(TestCase):
+    def setUp(self) -> None:
+        self.sample_denovo_variant = DenovoVariant(5, "AACC", "GT")
+
+    def test___ref_not_composed_of_ACGT_only___DenovoError_raised(self):
+        with self.assertRaises(DenovoError):
+            DenovoVariant(0, ref="ACGTB", alt="")
+
+    def test___alt_not_composed_of_ACGT_only___DenovoError_raised(self):
+        with self.assertRaises(DenovoError):
+            DenovoVariant(0, ref="", alt="ACGTB")
+
+    def test___ref_and_alt_are_identical___DenovoError_raised(self):
+        seq="ACGT"
+        with self.assertRaises(DenovoError):
+            DenovoVariant(0, ref=seq, alt=seq)
+
+    def test___negative_index_for_variant_pos___DenovoError_raised(self):
+        with self.assertRaises(DenovoError):
+            DenovoVariant(-1, "A", "C")
+
+    def test___constructor___variant_correctly_built(self):
+        ml_path_nodes_it_goes_through = [Mock(), Mock(), Mock(), Mock()]
+        denovo_variant = DenovoVariant(5, "AACC", "GT", ml_path_nodes_it_goes_through)
+        self.assertEqual(5, denovo_variant.start_index_in_linear_path)
+        self.assertEqual(9, denovo_variant.end_index_in_linear_path)
+        self.assertEqual("AACC", denovo_variant.ref)
+        self.assertEqual("GT", denovo_variant.alt)
+        self.assertEqual(ml_path_nodes_it_goes_through, denovo_variant.ml_path_nodes_it_goes_through)
+
+    def test___equality___same_variant(self):
+        ml_path_nodes_it_goes_through = [Mock()]
+        denovo_variant_1 = DenovoVariant(1, "A", "C", ml_path_nodes_it_goes_through)
+        denovo_variant_2 = DenovoVariant(1, "A", "C", ml_path_nodes_it_goes_through)
+        self.assertEqual(denovo_variant_1, denovo_variant_2)
+
+    def test___equality___different_variants(self):
+        ml_path_nodes_it_goes_through_1 = [Mock()]
+        denovo_variant_1 = DenovoVariant(1, "A", "C", ml_path_nodes_it_goes_through_1)
+
+        denovo_variant_2 = DenovoVariant(2, "A", "C", ml_path_nodes_it_goes_through_1)
+        self.assertNotEqual(denovo_variant_1, denovo_variant_2)
+
+        denovo_variant_2 = DenovoVariant(1, "T", "C", ml_path_nodes_it_goes_through_1)
+        self.assertNotEqual(denovo_variant_1, denovo_variant_2)
+
+        denovo_variant_2 = DenovoVariant(1, "A", "G", ml_path_nodes_it_goes_through_1)
+        self.assertNotEqual(denovo_variant_1, denovo_variant_2)
+
+        ml_path_nodes_it_goes_through_2 = [Mock()]
+        denovo_variant_2 = DenovoVariant(1, "A", "C", ml_path_nodes_it_goes_through_2)
+        self.assertNotEqual(denovo_variant_1, denovo_variant_2)
+
+    def test___equality___comparing_variant_with_other_type(self):
+        denovo_variant_1 = DenovoVariant(1, "A", "C")
+        other = "a string"
+        self.assertNotEqual(denovo_variant_1, other)
+
+    def test___set_ml_path_nodes_it_goes_through___ml_path_nodes_it_goes_through_is_None(self):
+        self.sample_denovo_variant.set_ml_path_nodes_it_goes_through(None)
+        self.assertIsNone(self.sample_denovo_variant.ml_path_nodes_it_goes_through)
+
+    def test___set_ml_path_nodes_it_goes_through___empty_path_error_out(self):
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.set_ml_path_nodes_it_goes_through([])
+
+    def test___set_ml_path_nodes_it_goes_through___one_node_less_than_expected_in_path_error_out(self):
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        ml_path_nodes_it_goes_through = [dummy_node, dummy_node, dummy_node]
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_it_goes_through)
+
+    def test___set_ml_path_nodes_it_goes_through___one_node_more_than_expected_in_path_error_out(self):
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        ml_path_nodes_it_goes_through = [dummy_node, dummy_node, dummy_node, dummy_node, dummy_node]
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_it_goes_through)
+
+    def test___set_ml_path_nodes_it_goes_through___each_base_is_covered_by_one_node(self):
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        ml_path_nodes_it_goes_through = [dummy_node, dummy_node, dummy_node, dummy_node]
+
+        self.sample_denovo_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_it_goes_through)
+
+        self.assertEqual(ml_path_nodes_it_goes_through, self.sample_denovo_variant.ml_path_nodes_it_goes_through)
+
+    def test___set_ml_path_nodes_it_goes_through___strict_insertion___no_ml_path_nodes_going_through_it_error_out(self):
+        denovo_variant = DenovoVariant(5, "", "ACGT")
+        with self.assertRaises(AssertionError):
+            denovo_variant.set_ml_path_nodes_it_goes_through([])
+
+    def test___set_ml_path_nodes_it_goes_through___strict_insertion___two_ml_path_nodes_going_through_it_error_out(self):
+        denovo_variant = DenovoVariant(5, "", "ACGT")
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        ml_path_nodes_it_goes_through = [dummy_node, dummy_node]
+        with self.assertRaises(AssertionError):
+            denovo_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_it_goes_through)
+
+    def test___set_ml_path_nodes_it_goes_through___strict_insertion_is_ok(self):
+        denovo_variant = DenovoVariant(5, "", "ACGT")
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        ml_path_nodes_it_goes_through = [dummy_node]
+
+        denovo_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_it_goes_through)
+
+        self.assertEqual(ml_path_nodes_it_goes_through, denovo_variant.ml_path_nodes_it_goes_through)
+
+    def test___get_mutated_sequence___ml_path_is_none___AssertionError_raised(self):
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.get_mutated_sequence()
+
+    def test___get_mutated_sequence___ml_path_is_empty___AssertionError_raised(self):
+        self.sample_denovo_variant.ml_path_nodes_it_goes_through = []
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.get_mutated_sequence()
+
+    def test___get_mutated_sequence___ml_path_has_two_distinct_nodes___AssertionError_raised(self):
+        self.sample_denovo_variant.ml_path_nodes_it_goes_through = [Mock(), Mock()]
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.get_mutated_sequence()
+
+    def test___get_mutated_sequence___bad_start_index_before_node_start_AssertionError_raised(self):
+        ml_path_node = MLPathNode(key=(6, 9), sequence="ACG")
+        ml_path_node.start_index_in_linear_path = 6
+        ml_path_node.end_index_in_linear_path = 9
+        self.sample_denovo_variant.set_ml_path_nodes_it_goes_through([ml_path_node]*4)
+
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.get_mutated_sequence()
+
+    def test___get_mutated_sequence___bad_end_index_after_node_end_AssertionError_raised(self):
+        ml_path_node = MLPathNode(key=(5, 8), sequence="ACG")
+        ml_path_node.start_index_in_linear_path = 5
+        ml_path_node.end_index_in_linear_path = 8
+        self.sample_denovo_variant.set_ml_path_nodes_it_goes_through([ml_path_node]*4)
+
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.get_mutated_sequence()
+
+    def test___get_mutated_sequence___node_seq_not_consistent_with_ref_AssertionError_raised(self):
+        ml_path_node = MLPathNode(key=(3, 13), sequence="GTAAGCGTCA")
+        ml_path_node.start_index_in_linear_path = 3
+        ml_path_node.end_index_in_linear_path = 13
+        self.sample_denovo_variant.set_ml_path_nodes_it_goes_through([ml_path_node]*4)
+
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.get_mutated_sequence()
+
+    def test___get_mutated_sequence(self):
+        ml_path_node = MLPathNode(key=(3, 13), sequence="GTAACCGTCA")
+        ml_path_node.start_index_in_linear_path = 3
+        ml_path_node.end_index_in_linear_path = 13
+        self.sample_denovo_variant.set_ml_path_nodes_it_goes_through([ml_path_node]*4)
+
+        expected = "GTGTGTCA"
+        actual = self.sample_denovo_variant.get_mutated_sequence()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___ml_path_nodes_it_goes_through_is_None___raises_Assertion_Error(self):
+        with self.assertRaises(AssertionError):
+            self.sample_denovo_variant.split_variant()
+
+    def test___split_variant___variant_goes_through_single_node___no_split(self):
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        # all 4 bases goes through this single node
+        self.sample_denovo_variant.ml_path_nodes_it_goes_through = [dummy_node, dummy_node, dummy_node, dummy_node]
+
+        expected = [self.sample_denovo_variant]
+        actual = self.sample_denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___deletion_var_goes_through_two_nodes_split_in_middle(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "CG")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "AC", "C", [dummy_node_1, dummy_node_1]),
+                    DenovoVariant(7, "GT", "G", [dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___deletion_variant_goes_through_two_nodes_split_in_middle_with_mismatch(self):
+        denovo_variant = DenovoVariant(5, "ACGTA", "CAT")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "ACG", "CA", [dummy_node_1, dummy_node_1, dummy_node_1]),
+                    DenovoVariant(8, "TA", "T", [dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___deletion_var_goes_through_two_nodes_split_in_start(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "GCG")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "AC", "GC", [dummy_node_1, dummy_node_1]),
+                    DenovoVariant(7, "GT", "G", [dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___deletion_var_goes_through_two_nodes_split_in_start___one_variant_removed(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "AC")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(7, "GT", "", [dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___deletion_var_goes_through_two_nodes_split_in_end(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "CCT")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "AC", "C", [dummy_node_1, dummy_node_1]),
+                    DenovoVariant(7, "GT", "CT", [dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___deletion_var_goes_through_two_nodes_split_in_end___one_variant_removed(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "GT")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "AC", "", [dummy_node_1, dummy_node_1])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___phased_snps_var_goes_through_two_nodes_split_in_middle(self):
+        denovo_variant = DenovoVariant(5, "AGCT", "TGCA")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "AG", "TG", [dummy_node_1, dummy_node_1]),
+                    DenovoVariant(7, "CT", "CA", [dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___phased_snps_var_goes_through_two_nodes_split_in_start(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "TCTT")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2, dummy_node_2, dummy_node_2]
+
+        expected = [DenovoVariant(5, "A", "T", [dummy_node_1]),
+                    DenovoVariant(6, "CGT", "CTT", [dummy_node_2, dummy_node_2, dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___phased_snps_var_goes_through_two_nodes_split_in_end(self):
+        denovo_variant = DenovoVariant(5, "ACGT", "AGGA")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_1, dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(5, "ACG", "AGG", [dummy_node_1, dummy_node_1, dummy_node_1]),
+                    DenovoVariant(8, "T", "A", [dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___insertion_var_goes_through_two_nodes_split_in_middle(self):
+        denovo_variant = DenovoVariant(5, "GC", "TGCA")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(5, "G", "TG", [dummy_node_1]),
+                    DenovoVariant(6, "C", "CA", [dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___insertion_var_goes_through_two_nodes_split_in_start___one_variant_removed(self):
+        denovo_variant = DenovoVariant(5, "TG", "CATG")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(5, "T", "CAT", [dummy_node_1])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___insertion_var_goes_through_two_nodes_split_in_end___one_variant_removed(self):
+        denovo_variant = DenovoVariant(5, "TG", "TGCA")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(6, "G", "GCA", [dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+
+    def test___split_variant___long_insertion_var_before_and_after_goes_through_two_nodes(self):
+        denovo_variant = DenovoVariant(5, "TG", "AAAATGCCCC")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(5, "T", "AAAAT", [dummy_node_1]),
+                    DenovoVariant(6, "G", "GCCCC", [dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___long_insertion_var_between_goes_through_two_nodes(self):
+        denovo_variant = DenovoVariant(5, "TG", "TAAAAG")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(6, "G", "AAAAG", [dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___long_insertion_var_before_after_and_between_goes_through_two_nodes(self):
+        denovo_variant = DenovoVariant(5, "TG", "AAAATCCCCGAAAA")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2]
+
+        expected = [DenovoVariant(5, "T", "AAAAT", [dummy_node_1]),
+                    DenovoVariant(6, "G", "CCCCGAAAA", [dummy_node_2])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___del_snp_ins_goes_through_three_nodes(self):
+        denovo_variant = DenovoVariant(5, "AAAAAACGGGGGCTTTT", "AATGGGGGATTCCTTCC")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        dummy_node_3 = MLPathNode(key=(2, 3), sequence="T")
+        # all 4 bases goes through this single node
+        denovo_variant.ml_path_nodes_it_goes_through = [
+            dummy_node_1, dummy_node_1, dummy_node_1, dummy_node_1, dummy_node_1, dummy_node_1,
+            dummy_node_2, dummy_node_2, dummy_node_2, dummy_node_2, dummy_node_2, dummy_node_2, dummy_node_2,
+            dummy_node_3, dummy_node_3, dummy_node_3, dummy_node_3]
+
+        expected = [DenovoVariant(5, "AAAAAA", "AA", [dummy_node_1]*6),
+                    DenovoVariant(11, "CGGGGGC", "TGGGGGA", [dummy_node_2]*7),
+                    DenovoVariant(18, "TTTT", "TTCCTTCC", [dummy_node_3]*4)]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___single_SNPs_through_several_nodes(self):
+        denovo_variant = DenovoVariant(5, "ACGTTCGT", "TCCAACGG")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        dummy_node_3 = MLPathNode(key=(2, 3), sequence="T")
+        dummy_node_4 = MLPathNode(key=(3, 4), sequence="A")
+        dummy_node_5 = MLPathNode(key=(4, 5), sequence="C")
+        dummy_node_6 = MLPathNode(key=(5, 6), sequence="T")
+        dummy_node_7 = MLPathNode(key=(6, 7), sequence="A")
+        dummy_node_8 = MLPathNode(key=(7, 8), sequence="C")
+        denovo_variant.ml_path_nodes_it_goes_through = [
+            dummy_node_1, dummy_node_2, dummy_node_3, dummy_node_4, dummy_node_5, dummy_node_6, dummy_node_7,
+            dummy_node_8]
+
+        expected = [DenovoVariant(5, "A", "T", [dummy_node_1]),
+                    DenovoVariant(7, "G", "C", [dummy_node_3]),
+                    DenovoVariant(8, "T", "A", [dummy_node_4]),
+                    DenovoVariant(9, "T", "A", [dummy_node_5]),
+                    DenovoVariant(12, "T", "G", [dummy_node_8])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___dels_through_several_nodes(self):
+        denovo_variant = DenovoVariant(5, "ACGTTCGT", "AGTG")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        dummy_node_3 = MLPathNode(key=(2, 3), sequence="T")
+        dummy_node_4 = MLPathNode(key=(3, 4), sequence="A")
+        dummy_node_5 = MLPathNode(key=(4, 5), sequence="C")
+        dummy_node_6 = MLPathNode(key=(5, 6), sequence="T")
+        dummy_node_7 = MLPathNode(key=(6, 7), sequence="A")
+        dummy_node_8 = MLPathNode(key=(7, 8), sequence="C")
+        denovo_variant.ml_path_nodes_it_goes_through = [
+            dummy_node_1, dummy_node_2, dummy_node_3, dummy_node_4, dummy_node_5, dummy_node_6, dummy_node_7,
+            dummy_node_8]
+
+        expected = [DenovoVariant(6, "C", "", [dummy_node_2]),
+                    DenovoVariant(9, "T", "", [dummy_node_5]),
+                    DenovoVariant(10, "C", "", [dummy_node_6]),
+                    DenovoVariant(12, "T", "", [dummy_node_8])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___strict_insertion(self):
+        denovo_variant = DenovoVariant(5, "", "ACGT")
+        dummy_node = MLPathNode(key=(0, 1), sequence="A")
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node]
+
+        expected = [denovo_variant]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___split_variant___middle_ml_path_node_is_removed(self):
+        denovo_variant = DenovoVariant(156, "TAG", "CTA")
+        dummy_node_1 = MLPathNode(key=(0, 1), sequence="A")
+        dummy_node_2 = MLPathNode(key=(1, 2), sequence="C")
+        dummy_node_3 = MLPathNode(key=(2, 3), sequence="T")
+        denovo_variant.ml_path_nodes_it_goes_through = [dummy_node_1, dummy_node_2, dummy_node_3]
+
+        expected = [DenovoVariant(156, "T", "CT", [dummy_node_1]),
+                    DenovoVariant(158, "G", "", [dummy_node_3])]
+        actual = denovo_variant.split_variant()
+
+        self.assertEqual(expected, actual)
+
+    def test___is_strict_insertion_event___true(self):
+        denovo_variant = DenovoVariant(5, "", "AGTG")
+        self.assertTrue(denovo_variant.is_strict_insertion_event())
+
+    def test___is_strict_insertion_event___false(self):
+        denovo_variant = DenovoVariant(5, "A", "AGTG")
+        self.assertFalse(denovo_variant.is_strict_insertion_event())
+
+    def test___str(self):
+        expected = "[5:9]:'AACC'->'GT'"
+        actual = str(self.sample_denovo_variant)
+        self.assertEqual(expected, actual)
+
+    def test___repr(self):
+        expected = "DenovoVariant(start_index_in_linear_path=5, ref=\"AACC\", alt=\"GT\")"
+        actual = repr(self.sample_denovo_variant)
+        self.assertEqual(expected, actual)

--- a/tests/update/test_DenovoVariantsDB.py
+++ b/tests/update/test_DenovoVariantsDB.py
@@ -1,0 +1,191 @@
+from unittest import TestCase
+from make_prg.update.denovo_variants import DenovoVariantsDB, DenovoVariant, UpdateData
+from make_prg.update.MLPath import MLPathNode, MLPathError, MLPath
+from io import StringIO
+from pathlib import Path
+
+
+class DenovoVariantsDBTest(TestCase):
+    def test___read_nb_of_samples(self):
+        handler = StringIO("2 samples\n")
+        expected = 2
+        actual = DenovoVariantsDB._read_nb_of_samples(handler)
+        self.assertEqual(expected, actual)
+
+    def test___read_sample(self):
+        handler = StringIO("Sample toy_sample_1\n")
+        expected = "toy_sample_1"
+        actual = DenovoVariantsDB._read_sample(handler)
+        self.assertEqual(expected, actual)
+
+    def test___read_nb_of_loci_in_sample(self):
+        handler = StringIO("23 loci with denovo variants\n")
+        expected = 23
+        actual = DenovoVariantsDB._read_nb_of_loci_in_sample(handler)
+        self.assertEqual(expected, actual)
+
+    def test___read_locus(self):
+        handler = StringIO("GC00010897\n")
+        expected = "GC00010897"
+        actual = DenovoVariantsDB._read_locus(handler)
+        self.assertEqual(expected, actual)
+
+    def test___read_nb_of_nodes_in_ml_path(self):
+        handler = StringIO("9 nodes \n")
+        expected = 9
+        actual = DenovoVariantsDB._read_nb_of_nodes_in_ml_path(handler)
+        self.assertEqual(expected, actual)
+
+    def test___read_MLPathNode(self):
+        handler = StringIO("(3 [121, 171) GAAATGCCCACGACCGGGCTGGATGAGCTGACAGAGGCCGAACGCGAGAC)\n")
+        expected = MLPathNode(key=(121, 171), sequence="GAAATGCCCACGACCGGGCTGGATGAGCTGACAGAGGCCGAACGCGAGAC")
+        actual = DenovoVariantsDB._read_MLPathNode(handler)
+        self.assertEqual(expected, actual)
+
+    def test___read_MLPathNode___badly_formed_line(self):
+        handler = StringIO("(3 [121, 171))\n")
+        with self.assertRaises(AssertionError):
+            DenovoVariantsDB._read_MLPathNode(handler)
+
+    def test___read_ml_path___empty_path___raises_MLPathError(self):
+        handler = StringIO("0 nodes \n")
+        with self.assertRaises(MLPathError):
+            DenovoVariantsDB._read_ml_path(handler)
+
+    def test___read_ml_path___empty_path_with_1_empty_node___raises_MLPathError(self):
+        handler = StringIO("1 nodes \n"
+                           "(0 [1, 1) )\n")
+        with self.assertRaises(MLPathError):
+            DenovoVariantsDB._read_ml_path(handler)
+
+    def test___read_ml_path___path_with_1_empty_node_1_non_empty_node(self):
+        handler = StringIO("2 nodes \n"
+                           "(0 [1, 1) )\n"
+                           "(1 [3, 10) ACGTACG)\n")
+
+        expected = MLPath([MLPathNode(key=(3, 10), sequence="ACGTACG")])
+        actual = DenovoVariantsDB._read_ml_path(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_ml_path___empty_path_with_2_empty_nodes_2_non_empty_node(self):
+        handler = StringIO("4 nodes \n"
+                           "(0 [1, 1) )\n"
+                           "(1 [3, 10) ACGTACG)\n"
+                           "(2 [15, 20) GGCCA)\n"
+                           "(3 [30, 30) )\n")
+
+        expected = MLPath([
+            MLPathNode(key=(3, 10), sequence="ACGTACG"),
+            MLPathNode(key=(15, 20), sequence="GGCCA"),
+        ])
+        actual = DenovoVariantsDB._read_ml_path(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_nb_of_variants(self):
+        handler = StringIO("42 denovo variants for this locus\n")
+
+        expected = 42
+        actual = DenovoVariantsDB._read_nb_of_variants(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_DenovoVariant___simple_SNP(self):
+        handler = StringIO("49\tA\tG\n")
+
+        expected = DenovoVariant(48, "A", "G")
+        actual = DenovoVariantsDB._read_DenovoVariant(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_DenovoVariant___simple_insertion(self):
+        handler = StringIO("49\t\tG\n")
+
+        expected = DenovoVariant(48, "", "G")
+        actual = DenovoVariantsDB._read_DenovoVariant(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_DenovoVariant___simple_deletion(self):
+        handler = StringIO("49\tA\t\n")
+
+        expected = DenovoVariant(48, "A", "")
+        actual = DenovoVariantsDB._read_DenovoVariant(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_DenovoVariant___larger_variation(self):
+        handler = StringIO("49\tACTGACTG\tGGAGCT\n")
+
+        expected = DenovoVariant(48, "ACTGACTG", "GGAGCT")
+        actual = DenovoVariantsDB._read_DenovoVariant(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_variants___no_variants(self):
+        handler = StringIO("0 denovo variants for this locus\n")
+
+        expected = []
+        actual = DenovoVariantsDB._read_variants(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_variants___one_variant(self):
+        handler = StringIO("1 denovo variants for this locus\n"
+                           "49\tA\tG\n")
+
+        expected = [DenovoVariant(48, "A", "G")]
+        actual = DenovoVariantsDB._read_variants(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___read_variants___three_variants(self):
+        handler = StringIO("3 denovo variants for this locus\n"
+                           "49\tA\tG\n"
+                           "314\tGT\tAC\n"
+                           "500\t\tA\n")
+
+        expected = [DenovoVariant(48, "A", "G"), DenovoVariant(313, "GT", "AC"), DenovoVariant(499, "", "A")]
+        actual = DenovoVariantsDB._read_variants(handler)
+
+        self.assertEqual(expected, actual)
+
+    def test___big_bang(self):
+        denovo_paths_filepath = "tests/data/update/denovo_paths.txt"
+
+        denovo_variants_DB = DenovoVariantsDB(denovo_paths_filepath)
+
+        self.assertEqual(Path(denovo_paths_filepath), denovo_variants_DB.filepath)
+        expected_locus_name_to_update_data = {
+            'GC00010897': [
+                UpdateData(ml_path_node_key=(0, 110),
+                           ml_path=denovo_variants_DB.locus_name_to_update_data['GC00010897'][0].ml_path,
+                           new_node_sequence="ATGCAGATACGTGAACAGGGCCGCAAAATTCAGTGCATCCGCATCGTGTACGACAAGGCCATTGGCCGGGGTCGGCAGACGGTCATTGCCACACTGGCCCGCTATACGAC"),
+                UpdateData(ml_path_node_key=(374, 491),
+                           ml_path=denovo_variants_DB.locus_name_to_update_data['GC00010897'][1].ml_path,
+                           new_node_sequence="GTCGGCAAGGCCTTGCGCAAGGCTGGTCACGCGAAGCCCAAGGCGGTCAGAAAGGGCAAGCCGGTCGATCCGGCTGATCCCAAGGATCAAGGGGTGGGGGCACCAAAGGGGAAATGA")
+            ],
+            'GC00006032': [
+                UpdateData(ml_path_node_key=(0, 145),
+                           ml_path=denovo_variants_DB.locus_name_to_update_data['GC00006032'][0].ml_path,
+                           new_node_sequence="TTGAGTAAAACAATCCCCCGCGCTTATATAAGCGCGTTGATATTTTTAGTTATTAACAAGCAACATCATGCTAATACAGACATACAAGGAGATCATCTCTCTTTGCCTGTTTTTTATTATTTCAGGAGTGTAAACACATTTTCCG")
+            ],
+            'Cluster_1011': [
+                UpdateData(ml_path_node_key=(930, 946),
+                           ml_path=denovo_variants_DB.locus_name_to_update_data['Cluster_1011'][0].ml_path,
+                           new_node_sequence="TTTTTGACCATTTCCA"),
+
+                UpdateData(ml_path_node_key=(955, 956),
+                           ml_path=denovo_variants_DB.locus_name_to_update_data['Cluster_1011'][1].ml_path,
+                           new_node_sequence="C")
+            ]}
+        self.assertEqual(expected_locus_name_to_update_data, denovo_variants_DB.locus_name_to_update_data)
+
+    def test___big_bang___empty(self):
+        denovo_paths_filepath = "tests/data/update/empty_denovo_paths.txt"
+
+        denovo_variants_DB = DenovoVariantsDB(denovo_paths_filepath)
+
+        self.assertEqual(Path(denovo_paths_filepath), denovo_variants_DB.filepath)
+        self.assertEqual({}, denovo_variants_DB.locus_name_to_update_data)

--- a/tests/update/test_MLPath.py
+++ b/tests/update/test_MLPath.py
@@ -1,0 +1,131 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from make_prg.update.MLPath import MLPathNode, MLPath, MLPathError
+from intervaltree import IntervalTree, Interval
+
+
+class MLPathTest(TestCase):
+    def setUp(self):
+        self.ml_path_node_1 = MLPathNode(key=(5, 9), sequence="ACGT")
+        self.ml_path_node_2 = MLPathNode(key=(12, 13), sequence="G")
+        self.ml_path_node_3 = MLPathNode(key=(20, 22), sequence="AA")
+        self.ml_path_nodes = [self.ml_path_node_1, self.ml_path_node_2, self.ml_path_node_3]
+        self.ml_path = MLPath(self.ml_path_nodes)
+
+    def test___constructor___empty_MLPath___raises_MLPathError(self):
+        with self.assertRaises(MLPathError):
+            MLPath([])
+
+    # TODO: might not be the best practice to check the private attributes in tests
+    # TODO: it breaks encapsulation
+    def test___constructor___single_MLPath(self):
+        ml_path_nodes = [self.ml_path_node_1]
+        ml_path = MLPath(ml_path_nodes)
+
+        self.assertEqual(ml_path_nodes, ml_path._ml_path_nodes)
+        expected_linear_path_space_index = IntervalTree([Interval(0, 4, self.ml_path_node_1)])
+        self.assertEqual(expected_linear_path_space_index, ml_path._ml_path_index_in_linear_path_space)
+        expected_PRG_space_index = {(5, 9): self.ml_path_node_1}
+        self.assertEqual(expected_PRG_space_index, ml_path._ml_path_index_in_PRG_space)
+
+    def test___constructor___MLPath_with_two_nodes(self):
+        ml_path_nodes = [self.ml_path_node_1, self.ml_path_node_2]
+        ml_path = MLPath(ml_path_nodes)
+
+        self.assertEqual(ml_path_nodes, ml_path._ml_path_nodes)
+        expected_linear_path_space_index = IntervalTree([
+            Interval(0, 4, self.ml_path_node_1),
+            Interval(4, 5, self.ml_path_node_2)
+        ])
+        self.assertEqual(expected_linear_path_space_index, ml_path._ml_path_index_in_linear_path_space)
+        expected_PRG_space_index = {(5, 9): self.ml_path_node_1,
+                                    (12, 13): self.ml_path_node_2}
+        self.assertEqual(expected_PRG_space_index, ml_path._ml_path_index_in_PRG_space)
+
+    def test___constructor___MLPath_with_three_nodes(self):
+        self.assertEqual(self.ml_path_nodes, self.ml_path._ml_path_nodes)
+        expected_linear_path_space_index = IntervalTree([
+            Interval(0, 4, MLPathNode(key=(5, 9), sequence="ACGT")),
+            Interval(4, 5, MLPathNode(key=(12, 13), sequence="G")),
+            Interval(5, 7, MLPathNode(key=(20, 22), sequence="AA"))
+        ])
+        self.assertEqual(expected_linear_path_space_index, self.ml_path._ml_path_index_in_linear_path_space)
+        expected_PRG_space_index = {(5, 9): self.ml_path_node_1,
+                                    (12, 13): self.ml_path_node_2,
+                                    (20, 22): self.ml_path_node_3}
+        self.assertEqual(expected_PRG_space_index, self.ml_path._ml_path_index_in_PRG_space)
+
+    def test___equality(self):
+        ml_path_2 = MLPath(self.ml_path_nodes)
+        self.assertEqual(self.ml_path, ml_path_2)
+
+    def test___inequality(self):
+        ml_path_2 = MLPath(self.ml_path_nodes)
+        ml_path_2._ml_path_nodes = Mock()
+        self.assertNotEqual(self.ml_path, ml_path_2)
+
+        ml_path_2 = MLPath(self.ml_path_nodes)
+        ml_path_2._ml_path_index_in_linear_path_space = Mock()
+        self.assertNotEqual(self.ml_path, ml_path_2)
+
+        ml_path_2 = MLPath(self.ml_path_nodes)
+        ml_path_2._ml_path_index_in_PRG_space = Mock()
+        self.assertNotEqual(self.ml_path, ml_path_2)
+
+    def test___inequality___other_type(self):
+        a_string = "a string"
+        self.assertNotEqual(self.ml_path, a_string)
+
+    def test___get_last_insertion_pos(self):
+        expected = 7
+        actual = self.ml_path.get_last_insertion_pos()
+        self.assertEqual(expected, actual)
+
+    def test___get_last_node(self):
+        expected = self.ml_path_node_3
+        actual = self.ml_path.get_last_node()
+        self.assertEqual(expected, actual)
+
+    def test___get_node_given_position_in_linear_path_space___positions_of_ml_path_node_1(self):
+        expected = self.ml_path_node_1
+        for position in range(0, 4):
+            actual = self.ml_path.get_node_given_position_in_linear_path_space(position)
+            self.assertEqual(expected, actual)
+
+    def test___get_node_given_position_in_linear_path_space___positions_of_ml_path_node_2(self):
+        expected = self.ml_path_node_2
+        actual = self.ml_path.get_node_given_position_in_linear_path_space(4)
+        self.assertEqual(expected, actual)
+
+    def test___get_node_given_position_in_linear_path_space___positions_of_ml_path_node_3(self):
+        expected = self.ml_path_node_3
+        for position in range(5, 7):
+            actual = self.ml_path.get_node_given_position_in_linear_path_space(position)
+            self.assertEqual(expected, actual)
+
+    def test___get_node_given_position_in_linear_path_space___one_position_over_the_last_one___raises_MLPathError(self):
+        with self.assertRaises(MLPathError):
+            self.ml_path.get_node_given_position_in_linear_path_space(7)
+
+    def test___get_node_given_position_in_linear_path_space___two_positions_over_the_last_one___raises_MLPathError(self):
+        with self.assertRaises(MLPathError):
+            self.ml_path.get_node_given_position_in_linear_path_space(8)
+
+    def test___get_node_given_interval_in_PRG_space___interval_not_indexed___raises_MLPathError(self):
+        with self.assertRaises(MLPathError):
+            self.ml_path.get_node_given_interval_in_PRG_space((5, 8))
+
+    def test___get_node_given_interval_in_PRG_space___interval_indexed___first_node(self):
+        expected = self.ml_path_node_1
+        actual = self.ml_path.get_node_given_interval_in_PRG_space((5, 9))
+        self.assertEqual(expected, actual)
+
+    def test___get_node_given_interval_in_PRG_space___interval_indexed___second_node(self):
+        expected = self.ml_path_node_2
+        actual = self.ml_path.get_node_given_interval_in_PRG_space((12, 13))
+        self.assertEqual(expected, actual)
+
+    def test___get_node_given_interval_in_PRG_space___interval_indexed___third_node(self):
+        expected = self.ml_path_node_3
+        actual = self.ml_path.get_node_given_interval_in_PRG_space((20, 22))
+        self.assertEqual(expected, actual)

--- a/tests/update/test_MLPathNode.py
+++ b/tests/update/test_MLPathNode.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+from make_prg.update.MLPath import MLPathNode, EmptyMLPathSequence, MLPathError
+
+class MLPathNodeTest(TestCase):
+    def test___constructor___invalid_sequence_raises_EmptyMLPathSequence(self):
+        with self.assertRaises(EmptyMLPathSequence):
+            MLPathNode((0, 0), sequence="")
+
+    def test___constructor___invalid_node_length_one_base_shorter_raises_MLPathError(self):
+        with self.assertRaises(MLPathError):
+            MLPathNode((5, 8), sequence="ACGT")
+
+    def test___constructor___invalid_node_length_one_base_longer_raises_MLPathError(self):
+        with self.assertRaises(MLPathError):
+            MLPathNode((5, 10), sequence="ACGT")
+
+    def test___constructor(self):
+        ml_path_node = MLPathNode((5, 9), sequence="ACGT")
+        self.assertEqual((5, 9), ml_path_node.key)
+        self.assertEqual("ACGT", ml_path_node.sequence)
+        self.assertEqual(None, ml_path_node.start_index_in_linear_path)
+        self.assertEqual(None, ml_path_node.end_index_in_linear_path)
+
+    def test___equality(self):
+        ml_path_node_1 = MLPathNode((5, 9), sequence="ACGT")
+        ml_path_node_2 = MLPathNode((5, 9), sequence="ACGT")
+        self.assertEqual(ml_path_node_1, ml_path_node_2)
+
+    def test___inequality(self):
+        ml_path_node_1 = MLPathNode((5, 9), sequence="ACGT")
+
+        ml_path_node_2 = MLPathNode((6, 10), sequence="ACGT")
+        self.assertNotEqual(ml_path_node_1, ml_path_node_2)
+
+        ml_path_node_2 = MLPathNode((5, 9), sequence="ACCT")
+        self.assertNotEqual(ml_path_node_1, ml_path_node_2)
+
+    def test___inequality___other_type(self):
+        ml_path_node_1 = MLPathNode((5, 9), sequence="ACGT")
+        a_string = "a string"
+        self.assertNotEqual(ml_path_node_1, a_string)
+
+    def test___str(self):
+        ml_path_node = MLPathNode((5, 9), sequence="ACGT")
+
+        expected = "PRG key = (5, 9); ML seq interval = [None:None]; Seq = ACGT"
+        actual = str(ml_path_node)
+
+        self.assertEqual(expected, actual)
+
+    def test___repr(self):
+        ml_path_node = MLPathNode((5, 9), sequence="ACGT")
+
+        expected = "MLPathNode(key=(5, 9), sequence=\"ACGT\")"
+        actual = repr(ml_path_node)
+
+        self.assertEqual(expected, actual)

--- a/tests/update/test_UpdateData.py
+++ b/tests/update/test_UpdateData.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from make_prg.update.denovo_variants import UpdateData
+
+class TestUpdateData(TestCase):
+    def test___constructor(self):
+        ml_path_node_key = Mock()
+        ml_path = Mock()
+        new_node_sequence = Mock()
+
+        update_data = UpdateData(ml_path_node_key, ml_path, new_node_sequence)
+
+        self.assertEqual(ml_path_node_key, update_data.ml_path_node_key)
+        self.assertEqual(ml_path, update_data.ml_path)
+        self.assertEqual(new_node_sequence, update_data.new_node_sequence)
+
+    def test___equality(self):
+        ml_path_node_key = Mock()
+        ml_path = Mock()
+        new_node_sequence = Mock()
+
+        update_data_1 = UpdateData(ml_path_node_key, ml_path, new_node_sequence)
+        update_data_2 = UpdateData(ml_path_node_key, ml_path, new_node_sequence)
+
+        self.assertEqual(update_data_1, update_data_2)
+
+    def test___inequality(self):
+        ml_path_node_key = Mock()
+        ml_path = Mock()
+        new_node_sequence = Mock()
+
+        update_data_1 = UpdateData(ml_path_node_key, ml_path, new_node_sequence)
+
+        update_data_2 = UpdateData(Mock(), ml_path, new_node_sequence)
+        self.assertNotEqual(update_data_1, update_data_2)
+
+        update_data_2 = UpdateData(ml_path_node_key, Mock(), new_node_sequence)
+        self.assertNotEqual(update_data_1, update_data_2)
+
+        update_data_2 = UpdateData(ml_path_node_key, ml_path, Mock())
+        self.assertNotEqual(update_data_1, update_data_2)
+
+    def test___inequality___with_other_type(self):
+        ml_path_node_key = Mock()
+        ml_path = Mock()
+        new_node_sequence = Mock()
+        update_data_1 = UpdateData(ml_path_node_key, ml_path, new_node_sequence)
+        a_string = "a string"
+
+        self.assertNotEqual(update_data_1, a_string)
+
+    def test___repr(self):
+        ml_path_node_key = "ml_path_node_key"
+        ml_path = "ml_path"
+        new_node_sequence = "new_node_sequence"
+        update_data_1 = UpdateData(ml_path_node_key, ml_path, new_node_sequence)
+
+        expected = "UpdateData(ml_path_node_key='ml_path_node_key', ml_path='ml_path', new_node_sequence='new_node_sequence')"
+        actual = repr(update_data_1)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Hello,
Proceeding with our PR series, this is the most crucial PR, which is the one that adds the `make_prg update` code itself. In the following, I will describe a general view of the code to help reviewing:

## Source file: `make_prg/update/denovo_variants.py`

### Class `DenovoVariantsDB`

Class used to parse a [denovo variants file](https://github.com/leoisl/make_prg/blob/update/sample_example/denovo_paths/denovo_paths.txt) and provide an index to easily find the updates to be done to a given locus (through member variable `self.locus_name_to_update_data`). It is mostly composed of methods to parse the file and build objects based on the parsed data.

### Class `DenovoLocusInfo` 

Represents all the information of a denovo locus in a [denovo variants file](https://github.com/leoisl/make_prg/blob/update/sample_example/denovo_paths/denovo_paths.txt), e.g. sample, locus name, the ML path through the locus in that sample, and all denovo variants found for that locus for that sample. It is mainly used internally by `DenovoVariantsDB` to get update data for a given locus.

### Class `UpdateData`

Trivial class used to hold updates to be done in a given node of a locus.

### Class `DenovoVariant`

Represents a denovo variant with a ref and alt, and the chromosome would be a ML path through a locus. The ref can go through a single or multiple nodes of the ML path. If it goes through a single node, we can apply the variant to it and get a new sequence (`get_mutated_sequence()`). If it goes through multiple nodes, we can split this variant into a list of sub-variants WRT how it is distributed along the ML path (`split_variant()`).

## Source file: `make_prg/update/MLPath.py`

### Class `MLPath`

Represents a ML path that is indexed in two spaces (path and PRG spaces) for quick queries by other objects.

### Class `MLPathNode`

Represents nodes of the ML path.

## Source file: `make_prg/recursion_tree.py`

This source file contains the classes required to represent the recursion tree of the PRG explicitly. We have two types of nodes in our recursion tree: `MultiClusterNode` and `SingleClusterNode`. `MultiClusterNode` represents a node in the recursion tree such that its respective MSA has to be clustered in two or more clusters, e.g. a non-match interval with at least two groups of different enough sequences. `MultiClusterNode`s are never leaves. `SingleClusterNode` represents nodes such that the sequences of the respective MSA constitute a single cluster (e.g. when the sequences are too close to each other). It is also used when we still don't know how we will cluster the MSA (as concrete examples, the root is always a `SingleClusterNode`, as we don't know how it will be clustered yet, and children of `MultiClusterNode`s are always `SingleClusterNode`s). Depending on the MSA that the `SingleClusterNode` represents, it can have multiple `MultiClusterNode`s and `SingleClusterNode`s children.

In general, a node in the recursion tree stores a bunch of information that would match the recursive call at that point, e.g. nesting level, the MSA itself, parent node, its children, etc. Many of this information and methods are common between `MultiClusterNode`s and `SingleClusterNode`s, so the commonalities were refactored into a single abstract class `RecursiveTreeNode`. Finally, in order to build the PRG from a node, it is enough to traverse it in a preorder, which is the same order of the calls in a recursive algorithm (see `preorder_traversal_to_build_prg()`). `MultiClusterNode` has some unique behaviours, e.g. it is the only type of node that can cluster, while `SingleClusterNode` are the only type of nodes that can be updated. 

This is an example of the recursion tree of a PRG with two `MultiClusterNode`s (in red) and several `SingleClusterNode`s (in blue). Internal MSAs are not represented. Site 15 is not broken into a `MultiClusterNode` because it is actually composed of a single cluster ([this is the case when sequences are all too different](https://github.com/leoisl/make_prg/blob/36d8d5c2179420ce40bfd32c3ef4538955c02650/make_prg/from_msa/cluster_sequences.py#L255)). Sites 17 and 19 are not broken into `MultiClusterNode`s [because it has too few unique sequences (this is a recent optimisation done by @bricoletc that was ported to this code)](https://github.com/leoisl/make_prg/blob/36d8d5c2179420ce40bfd32c3ef4538955c02650/make_prg/recursion_tree.py#L154-L156).

![image](https://user-images.githubusercontent.com/8397967/150559168-7b232b2a-f745-4d28-91a4-598681d7f1f4.png)

## Source file: `make_prg/prg_builder.py`

### Class `PrgBuilder`

PRG builder based from a multiple sequence alignment. Similar to the existing `PrgBuilder` class, with a few differences, most notably:
1. It now also owns a MSA aligner (`self.aligner`), so that it can rebuild some alignments during the update command;
2. It has an index on the PRG space (`self.prg_index`);
3. It points to a `SingleClusterNode`, which is the root of the recursion tree of this locus' PRG;
4. It can be deserialised and serialised to disk;

### Class `PrgBuilderZipDatabase`

Represents a collection of `PrgBuilder`s, to be saved to and loaded from a zip file.