### PR TITLE
make_prg update PR series: 5. CLI changes

### DIFF
--- a/make_prg/subcommands/from_msa.py
+++ b/make_prg/subcommands/from_msa.py
@@ -29,6 +29,17 @@ def register_parser(subparsers):
         ),
     )
     subparser_msa.add_argument(
+        "-s",
+        "--suffix",
+        action="store",
+        type=str,
+        default="",
+        help=(
+            "If the input parameter (-i, --input) is a directory, then filter for files with this suffix. "
+            "If this parameter is not given, all files in the input directory is considered."
+        ),
+    )
+    subparser_msa.add_argument(
         "-o",
         "--output-prefix",
         dest="output_prefix",
@@ -75,7 +86,7 @@ def register_parser(subparsers):
     return subparser_msa
 
 
-def get_all_input_files(input_path: str) -> List[Path]:
+def get_all_input_files(input_path: str, suffix: str) -> List[Path]:
     input_path = Path(input_path)
     if not input_path.exists():
         raise FileNotFoundError(f"{input_path} does not exist")
@@ -84,7 +95,7 @@ def get_all_input_files(input_path: str) -> List[Path]:
         all_files = [input_path]
     else:
         all_files = [
-            path.resolve() for path in input_path.iterdir() if path.is_file()
+            path.resolve() for path in input_path.iterdir() if path.is_file() and path.name.endswith(suffix)
         ]
     return all_files
 
@@ -132,7 +143,7 @@ def run(cl_options):
     options = cl_options
 
     logger.info("Getting input files...")
-    input_files = get_all_input_files(options.input)
+    input_files = get_all_input_files(options.input, options.suffix)
 
     there_is_no_input_files = len(input_files) == 0
     if there_is_no_input_files:

--- a/make_prg/subcommands/update.py
+++ b/make_prg/subcommands/update.py
@@ -57,7 +57,8 @@ def register_parser(subparsers):
         ),
     )
     subparser_update_prg.add_argument(
-        "--long-deletion-threshold",
+        "-D",
+        "--deletion-threshold",
         dest="long_deletion_threshold",
         action="store",
         type=int,

--- a/make_prg/subcommands/update.py
+++ b/make_prg/subcommands/update.py
@@ -57,6 +57,17 @@ def register_parser(subparsers):
         ),
     )
     subparser_update_prg.add_argument(
+        "--long-deletion-threshold",
+        dest="long_deletion_threshold",
+        action="store",
+        type=int,
+        default=10,
+        help=(
+            "Ignores long deletions of the given size or longer. If long deletions should not be ignored, "
+            "put a large value. Default: %(default)d"
+        ),
+    )
+    subparser_update_prg.add_argument(
         "-m",
         "--mafft",
         help="Path to MAFFT executable. By default, it is assumed to be on $PATH",
@@ -163,7 +174,7 @@ def run(cl_options):
         prg_builder_zip_db = PrgBuilderZipDatabase(options.update_DS)
         prg_builder_zip_db.load()
         logger.info(f"Reading {options.denovo_paths}...")
-        denovo_variants_db = DenovoVariantsDB(options.denovo_paths)
+        denovo_variants_db = DenovoVariantsDB(options.denovo_paths, options.long_deletion_threshold)
         update_shared_data = UpdateSharedData(denovo_variants_db, mafft_aligner)
 
         output_dir = Path(options.output_prefix).parent

--- a/make_prg/update/denovo_variants.py
+++ b/make_prg/update/denovo_variants.py
@@ -161,9 +161,9 @@ class DenovoVariant:
                     ml_path_nodes_the_split_variant_goes_through = [ml_path_node] * len(sub_ref_seq)
                     split_variant.set_ml_path_nodes_it_goes_through(ml_path_nodes_the_split_variant_goes_through)
                     split_variants.append(split_variant)
-                    logger.info(f"Split variant to be applied: {split_variant}")
+                    logger.debug(f"Split variant to be applied: {split_variant}")
                 except TooLongDeletion as error:
-                    logger.info(f"Ignoring split variant: {error}")
+                    logger.debug(f"Ignoring split variant: {error}")
 
         return split_variants
 
@@ -378,7 +378,7 @@ class DenovoVariantsDB:
                 long_deletion_threshold=long_deletion_threshold
         )
 
-        logger.info(f"Read variant: {denovo_variant}")
+        logger.debug(f"Read variant: {denovo_variant}")
         return denovo_variant
 
     @classmethod
@@ -390,7 +390,7 @@ class DenovoVariantsDB:
                 denovo_variant = cls._read_DenovoVariant(filehandler, long_deletion_threshold)
                 variants.append(denovo_variant)
             except TooLongDeletion as error:
-                logger.info(f"Ignoring variant: {error}")
+                logger.debug(f"Ignoring variant: {error}")
         return variants
 
     def _get_locus_name_to_denovo_loci_core(self, filehandler: TextIO) -> Dict[str, List[DenovoLocusInfo]]:

--- a/make_prg/update/denovo_variants.py
+++ b/make_prg/update/denovo_variants.py
@@ -163,7 +163,7 @@ class DenovoVariant:
                     split_variants.append(split_variant)
                     logger.debug(f"Split variant to be applied: {split_variant}")
                 except TooLongDeletion as error:
-                    logger.debug(f"Ignoring split variant: {error}")
+                    logger.warning(f"Ignoring split variant: {error}")
 
         return split_variants
 
@@ -390,7 +390,7 @@ class DenovoVariantsDB:
                 denovo_variant = cls._read_DenovoVariant(filehandler, long_deletion_threshold)
                 variants.append(denovo_variant)
             except TooLongDeletion as error:
-                logger.debug(f"Ignoring variant: {error}")
+                logger.warning(f"Ignoring variant: {error}")
         return variants
 
     def _get_locus_name_to_denovo_loci_core(self, filehandler: TextIO) -> Dict[str, List[DenovoLocusInfo]]:


### PR DESCRIPTION
1. Adds `--suffix` parameter to `make_prg from_msa`. This is in general useful, but it is actually required to use `make_prg` in a `snakemake` pipeline. The main issue I faced is that a `snakemake` pipeline is creating a dir of MSAs to be fed into `make_prg from_msa`, but currently just using the `--input` parameter and giving a dir as input tries to build a PRG from every file in the dir, including the `.snakemake_timestamp` file. This allows us to further filter out which files we want to build a PRG from;
2. Adds `--long-deletion-threshold` parameter to `make_prg update`. Current `make_prg update` implementation has issues dealing with long deletions, this parameter controls the size of the deletion we consider and ignore.