### PR TITLE
Implements update_shared_data as a class attribute in a singleton pattern and drops Mac OS X support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.8, 3.9, '3.10', '3.11' ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
     defaults:
       run:
         shell: bash -el {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ operations.
 - Several minor bugs;
 - Heavy refactoring of almost the whole codebase;
 
+### Removed
+- Support for `Mac OS X`;
+
 ## [0.2.0] - 2021-10-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 A tool to create and update PRGs for input to [Pandora][pandora] and [Gramtools][gramtools] from a set of 
 Multiple Sequence Alignments.
 
+# Support
+
+We fully support `make_prg` on `linux`.
+No guarantees are made for other operating systems.
+
 [TOC]: #
 
 ## Table of Contents

--- a/justfile
+++ b/justfile
@@ -23,10 +23,6 @@ fmt:
 install:
     poetry install
 
-# installs all extra packages
-install_full:
-    poetry install --extras "debug_graphs"
-
 install-ci: install-mafft
     poetry install --no-interaction
 

--- a/make_prg/update/update_shared_data.py
+++ b/make_prg/update/update_shared_data.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from loguru import logger
+
+from make_prg.update.denovo_variants import DenovoVariantsDB
+from make_prg.utils.msa_aligner import MSAAligner
+
+
+@dataclass
+class UpdateSharedData:
+    """
+    Data that is shared between child processes
+    """
+
+    denovo_variants_db: DenovoVariantsDB
+    aligner: MSAAligner
+
+
+class SingletonUpdateSharedData(object):
+    """
+    This class follows the singleton pattern and represents read-only data that is shared between child processes
+    when running make_prg update. As python does not implement multithreading, we have to use multiprocessing. However,
+    we can still efficiently share in-memory data between a parent process and a list of child processes with the copy-on-write
+    optimisation present in Unix systems (https://en.wikipedia.org/wiki/Copy-on-write). As long as the data does not
+    change, the child processes will refer to the parent process data in memory. If we give this large data as input to
+    the multiprocessing task, it will be pickled/unpickled, severely reducing efficiency. The programmer is responsible
+    to not modify the data in the multiprocessing parts.
+    Adapted from https://www.geeksforgeeks.org/singleton-pattern-in-python-a-complete-guide/
+    """
+
+    # create the singleton
+    def __new__(
+        cls,
+        denovo_variants_db: Optional[DenovoVariantsDB] = None,
+        aligner: Optional[MSAAligner] = None,
+    ):
+        if not hasattr(cls, "instance"):
+            logger.trace("Creating SingletonUpdateSharedData")
+            cls.instance = super(SingletonUpdateSharedData, cls).__new__(cls)
+            cls.instance.data = None
+        return cls.instance
+
+    # the first time constructing an object of this class, we need valid denovo_variants_db and aligner to correctly
+    # initialise the singleton. For the subsequent constructions, these parameters are ignored
+    def __init__(
+        self,
+        denovo_variants_db: Optional[DenovoVariantsDB] = None,
+        aligner: Optional[MSAAligner] = None,
+    ):
+        singleton_has_not_been_initialised = self.__class__.instance.data is None
+        if singleton_has_not_been_initialised:
+            logger.trace("Initialising SingletonUpdateSharedData")
+            self.__class__.instance.data = UpdateSharedData(denovo_variants_db, aligner)

--- a/poetry.lock
+++ b/poetry.lock
@@ -396,6 +396,14 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
@@ -492,6 +500,18 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "pytest-forked"
+version = "1.4.0"
+description = "run tests in isolated forked subprocesses"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+py = "*"
+pytest = ">=3.10"
 
 [[package]]
 name = "python-dateutil"
@@ -637,7 +657,7 @@ precompiled-binary = ["pygraphviz", "networkx", "matplotlib", "pyinstaller"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<=3.11"
-content-hash = "3771ef2b5f0e9a7350e91914f0284d68c3a4f73bb31e3d260734867b65f4db07"
+content-hash = "f33841edf5362d8d9e524af3b7c777381f1bf5ddcfb7c1491b4e6edf458c462c"
 
 [metadata.files]
 altgraph = [
@@ -1126,6 +1146,10 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
@@ -1165,6 +1189,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
     {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+]
+pytest-forked = [
+    {file = "pytest-forked-1.4.0.tar.gz", hash = "sha256:8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e"},
+    {file = "pytest_forked-1.4.0-py3-none-any.whl", hash = "sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pyinstaller = {version = "^5.6", optional = true}
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"
 pytest-cov = "^4.0.0"
+pytest-forked = "^1.4.0"
 hypothesis = "^6.24.5"
 black = "^22.10.0"
 isort = "^5.10.1"

--- a/tests/integration_tests/test_update.py
+++ b/tests/integration_tests/test_update.py
@@ -2,6 +2,8 @@ from argparse import Namespace
 from pathlib import Path
 from unittest import TestCase
 
+import pytest
+
 from make_prg.subcommands import output_type, update
 from tests.test_helpers import are_dir_trees_equal, remove_dir_if_exists
 
@@ -9,6 +11,7 @@ data_dir = Path("tests/integration_tests/data")
 
 
 # NOTE: for these tests we need mafft in $PATH
+@pytest.mark.forked
 class Test_Update_Integration_Full_Builds(TestCase):
     def prepare_options(self, test_name: str, update_DS: Path):
         output_folder = data_dir / "output_update" / test_name


### PR DESCRIPTION
Sorry that this PR is now doing two things.

This PR firstly describes the implementation of `update_shared_data` as a class attribute in a singleton pattern. This has the benefit of sharing in-memory data efficiently between the parent and child processes when multiprocessing during `make_prg update` operation, without the drawbacks of using `global`. Due to how singleton objects work, the update integration tests now have to run on different subprocesses, so `pytest-forked = "^1.4.0"` has to be added to `dev.dependencies`. Closes #45 

Secondly, it drops support for `Mac OS X`. There are several reasons:
1. Our tools that depend on `make_prg` are mostly tested on `linux`, e.g. `make_prg` and `pandora` provides precompiled binaries just for `linux`, and sample example use these (easy to change though);
2. `pandora` is just available on linux through `conda`;
3. `pandora` does not implement multithreading in `Mac OS X`;
4. next release of `pandora` has not been tested on `Mac OS X`;
5. `drprg` is tested just on linux runners;
6. See slack for more discussion on this;

This support drop can be just temporary. Now we can proceed and finish the new `make_prg` and `pandora` releases this week, enabling `drprg` to use these new releases. We can discuss further, and if we decide to indeed support `Mac OS x`, we can work on this support next week.